### PR TITLE
Strict mypy follow up fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,15 @@ $ pipx install --suffix=@next 'unihan-etl' --pip-args '\--pre' --force
 
 - _Insert changes/features/fixes for next release here_
 
+## unihan-etl 0.17.1 (unreleased)
+
+Follow ups to #257.
+
+### Fixes
+
+- `merged_dict()`: Fix merging edgecase where destination key was missing
+- `download()`: Fix edgecase when "downloading" file from local path
+
 ## unihan-etl 0.17.0 (2022-08-21)
 
 ### Features

--- a/unihan_etl/process.py
+++ b/unihan_etl/process.py
@@ -321,9 +321,6 @@ def download(
         log.info(f"{url} to {dest}")
         if os.path.isfile(url):
             shutil.copy(url, dest)
-
-        if reporthook is not None:
-            urlretrieve_fn(url, dest, reporthook)
         else:
             urlretrieve_fn(url, dest, reporthook)
 

--- a/unihan_etl/util.py
+++ b/unihan_etl/util.py
@@ -115,6 +115,7 @@ def merge_dict(
         if isinstance(value, t.Mapping):
             assert isinstance(key, str)
             assert isinstance(value, dict)
+            merged.setdefault(key, {})
             merged[key] = merge_dict(merged[key], value)
         else:
             merged[key] = value


### PR DESCRIPTION
Follow up to #257

- `merged_dict()`: Fix merging edgecase where destination key was missing
- `download()`: Fix edgecase when "downloading" file from local path 