### PR TITLE
docs: Move to `gp-libs` (our internal helpers for sphinx)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,12 +24,22 @@ $ pipx install --suffix=@next unihan-etl --pip-args '\--pre' --force
 - Add [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) (#263)
 - Add [flake8-comprehensions](https://github.com/adamchainz/flake8-comprehensions) (#264)
 
+### Documentation
+
+- Render changelog in [`linkify_issues`] (~~#261~~, #265)
+- Fix Table of contents rendering with sphinx autodoc with [`sphinx_toctree_autodoc_fix`] (#265)
+- Test doctests in our docs via [`pytest_doctest_docutils`] (built on [`doctest_docutils`]) (#265)
+
+[`linkify_issues`]: https://gp-libs.git-pull.com/linkify_issues/
+[`sphinx_toctree_autodoc_fix`]: https://gp-libs.git-pull.com/sphinx_toctree_autodoc_fix/
+[`pytest_doctest_docutils`]: https://gp-libs.git-pull.com/doctest/pytest.html
+[`doctest_docutils`]: https://gp-libs.git-pull.com/doctest
+
 ## unihan-etl 0.17.2 (2022-08-21)
 
 ### Documentation
 
-- Add vendorized, updated fork of
-  [sphinxcontrib-issuetracker](https://github.com/ignatenkobrain/sphinxcontrib-issuetracker), via #261.
+- Add vendorized, updated fork of `sphinxcontrib-issuetracker`, via #261.
 - Remove sphinx-issues package
 
 ## unihan-etl 0.17.1 (2022-08-21)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,14 +33,19 @@ extensions = [
     "sphinxext.opengraph",
     "sphinxext.rediraffe",
     "myst_parser",
-    "sphinx_autoissues",
+    "sphinx_toctree_autodoc_fix",
+    "linkify_issues",
+]
+myst_enable_extensions = [
+    "colon_fence",
+    "substitution",
+    "replacements",
+    "strikethrough",
 ]
 
 templates_path = ["_templates"]
 
 source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
-
-myst_enable_extensions = ["colon_fence", "substitution", "replacements"]
 
 master_doc = "index"
 
@@ -88,6 +93,9 @@ html_sidebars = {
     ]
 }
 
+# linkify_issues
+issue_url_tpl = "https://github.com/cihai/unihan-etl/issues/{issue_id}"
+
 # sphinxext.opengraph
 ogp_site_url = about["__docs__"]
 ogp_image = "_static/img/icons/icon-192x192.png"
@@ -100,10 +108,6 @@ copybutton_prompt_text = (
 )
 copybutton_prompt_is_regexp = True
 copybutton_remove_prompts = True
-
-# sphinx-autoissues
-issuetracker = "github"
-issuetracker_project = "cihai/unihan-etl"
 
 # sphinxext-rediraffe
 rediraffe_redirects = "redirects.txt"

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,6 @@
 :hidden:
 
 quickstart
-about
 cli
 api
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -696,14 +696,6 @@ testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "diff-cover (>=6.5.1)", 
 type_comments = ["typed-ast (>=1.5.4)"]
 
 [[package]]
-name = "sphinx-autoissues"
-version = "0.0.1"
-description = "Sphinx integration with different issuetrackers"
-category = "dev"
-optional = false
-python-versions = ">=3.7,<4.0"
-
-[[package]]
 name = "sphinx-basic-ng"
 version = "0.0.1a12"
 description = "A modern skeleton for Sphinx themes."
@@ -977,7 +969,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6b4b4a16b9157c17afc07a34c07f91e0021bf1aa77607742b29fdf35f5621a8b"
+content-hash = "8b329fc425c1945ae83869cc84176002137946e60fa07449247400dbac51b089"
 
 [metadata.files]
 alabaster = [
@@ -1362,10 +1354,6 @@ sphinx-autobuild = [
 sphinx-autodoc-typehints = [
     {file = "sphinx_autodoc_typehints-1.19.2-py3-none-any.whl", hash = "sha256:3d761de928d5a86901331133d6d4a2552afa2e798ebcfc0886791792aeb4dd9a"},
     {file = "sphinx_autodoc_typehints-1.19.2.tar.gz", hash = "sha256:872fb2d7b3d794826c28e36edf6739e93549491447dcabeb07c58855e9f914de"},
-]
-sphinx-autoissues = [
-    {file = "sphinx-autoissues-0.0.1.tar.gz", hash = "sha256:a308fd914d700ff2aa2b4584c29975a030ede7171898130ec816eca7ec2c8ce8"},
-    {file = "sphinx_autoissues-0.0.1-py3-none-any.whl", hash = "sha256:07503b774c3a64b97d2614fa409410316fbfeb87ba4553dbe3a7d2131b7453a0"},
 ]
 sphinx-basic-ng = [
     {file = "sphinx_basic_ng-0.0.1a12-py3-none-any.whl", hash = "sha256:e8b6efd2c5ece014156de76065eda01ddfca0fee465aa020b1e3c12f84570bbe"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -206,6 +206,18 @@ sphinx = ">=4.0,<6.0"
 sphinx-basic-ng = "*"
 
 [[package]]
+name = "gp-libs"
+version = "0.0.1a9"
+description = "Internal utilities for projects following git-pull python package spec"
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+docutils = ">=0.18.0,<0.19.0"
+myst_parser = "*"
+
+[[package]]
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -965,7 +977,7 @@ test = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "0cbe50b9d4abdb5b7c9ec9d4d309d075005bf32774f2e35ec856afb2b125f81a"
+content-hash = "6b4b4a16b9157c17afc07a34c07f91e0021bf1aa77607742b29fdf35f5621a8b"
 
 [metadata.files]
 alabaster = [
@@ -1105,6 +1117,10 @@ flake8-comprehensions = [
 furo = [
     {file = "furo-2022.6.21-py3-none-any.whl", hash = "sha256:061b68e323345e27fcba024cf33a1e77f3dfd8d9987410be822749a706e2add6"},
     {file = "furo-2022.6.21.tar.gz", hash = "sha256:9aa983b7488a4601d13113884bfb7254502c8729942e073a0acb87a5512af223"},
+]
+gp-libs = [
+    {file = "gp-libs-0.0.1a9.tar.gz", hash = "sha256:835608ba29220c4d77e7e3f5a9ae27368ac1eb4b43f0cd1e6cdec9c27e9a9e3a"},
+    {file = "gp_libs-0.0.1a9-py3-none-any.whl", hash = "sha256:2c055bd65f0880325a800775a2ee4c23dacc9eb8a56408fdb665a66da7d38ed3"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ sphinx-inline-tabs = { version = "*", python = "^3.7" }
 sphinxext-opengraph = "*"
 sphinx-copybutton = "*"
 sphinxext-rediraffe = "*"
-sphinx-autoissues = "*"
 myst_parser = "*"
 docutils = "~0.18.0"
 
@@ -111,7 +110,6 @@ docs = [
   "sphinxext-opengraph",
   "sphinx-inline-tabs",
   "sphinxext-rediraffe",
-  "sphinx-autoissues",
   "myst_parser",
   "furo",
   "gp-libs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ zhon = "*"
 sphinx = "*"
 sphinx-argparse = "*"
 furo = "*"
+gp-libs = "*"
 sphinx-autobuild = "*"
 sphinx-autodoc-typehints = "*"
 sphinx-inline-tabs = { version = "*", python = "^3.7" }
@@ -113,6 +114,7 @@ docs = [
   "sphinx-autoissues",
   "myst_parser",
   "furo",
+  "gp-libs",
 ]
 test = ["pytest", "pytest-rerunfailures", "pytest-watcher"]
 coverage = ["codecov", "coverage", "pytest-cov"]


### PR DESCRIPTION
## Changes

- Render changelog in [`linkify_issues`] 
- Fix Table of contents rendering with sphinx autodoc with [`sphinx_toctree_autodoc_fix`]
- Deprecate `sphinx-autoapi`, per above fixing the table of contents issue

  This also removes the need to workaround autoapi bugs.
- Test doctests in our docs via [`pytest_doctest_docutils`] (built on [`doctest_docutils`])

[`linkify_issues`]: https://gp-libs.git-pull.com/linkify_issues/
[`sphinx_toctree_autodoc_fix`]: https://gp-libs.git-pull.com/sphinx_toctree_autodoc_fix/
[`pytest_doctest_docutils`]: https://gp-libs.git-pull.com/doctest/pytest.html
[`doctest_docutils`]: https://gp-libs.git-pull.com/doctest