### PR TITLE
fix(pytest-plugin[zshrc]): Revert change

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,7 +19,17 @@ $ pipx install --suffix=@next unihan-etl --pip-args '\--pre' --force
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
+## unihan-etl 0.25.2 (2023-07-08)
+
+### Bug Fixes
+
+- pytest plugin: Revert fix of `zshrc` fixture's `skipif` condition (#293)
+
+  It was fine as-is.
+
 ## unihan-etl 0.25.1 (2023-07-08)
+
+*Rolled back*
 
 ### Bug Fixes
 

--- a/src/unihan_etl/pytest_plugin.py
+++ b/src/unihan_etl/pytest_plugin.py
@@ -44,7 +44,7 @@ def user_path(home_path: pathlib.Path, home_user_name: str) -> pathlib.Path:
     return p
 
 
-@pytest.mark.skipif(not USING_ZSH, reason="Using ZSH")
+@pytest.mark.skipif(USING_ZSH, reason="Using ZSH")
 @pytest.fixture(scope="session")
 def zshrc(user_path: pathlib.Path) -> pathlib.Path:
     """This quiets ZSH default message.


### PR DESCRIPTION
`zshrc` was fine as-is, reverts #292