### PR TITLE
pytest_plugin: Redesign with dataclass fixtures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,7 +32,60 @@ Then run `unihan-etl@next`.
 
 <!-- Maintainers, insert changes / features for the next release here -->
 
-_Add your latest changes from PRs here_
+### Breaking changes
+
+#### pytest plugin: Fixture dataclass containers (#341)
+
+Fixtures that previously returned `zipfile.ZipFile` now return `UnihanZip` dataclass:
+
+- `unihan_quick_zip` → returns `UnihanZip` (was `zipfile.ZipFile`)
+- `unihan_mock_zip` → returns `UnihanZip` (was `zipfile.ZipFile`)
+
+**Migration:**
+
+```python
+# Before (broken - ZipFile was closed before return!)
+def test_example(unihan_mock_zip: zipfile.ZipFile) -> None:
+    files = unihan_mock_zip.namelist()
+
+# After
+from unihan_etl.types import UnihanZip
+
+def test_example(unihan_mock_zip: UnihanZip) -> None:
+    with unihan_mock_zip.open() as zf:
+        files = zf.namelist()
+    # Or use convenience property:
+    files = unihan_mock_zip.namelist
+```
+
+See {ref}`MIGRATION <migration>` for full details.
+
+### Features
+
+#### pytest plugin: New dataclass types (#341)
+
+New typed containers in `unihan_etl.types` for pytest fixtures:
+
+- `UnihanZip`: Container for zip file with `path`, `open()`, `namelist`, `extract()`, `exists()`
+- `UnihanDataset`: Complete dataset container with `name`, `root`, `zip`, `work_dir`, `destination`, `is_ready`
+- `UnihanData`: Lazy-loaded data with `.normalized`, `.expanded`, `.by_char` properties
+
+#### pytest plugin: New fixtures (#341)
+
+- `unihan_quick` → `UnihanDataset` (primary fixture for quick dataset)
+- `unihan_full` → `UnihanDataset` (primary fixture for full dataset)
+- `unihan_quick_data_lazy` → `UnihanData` (lazy-loaded data container)
+
+#### pytest plugin: CLI option and marker (#341)
+
+- `--unihan-cache-dir`: Override cache directory via command line
+- `@pytest.mark.unihan_full`: Mark tests requiring full UNIHAN dataset
+
+### Bug fixes
+
+#### pytest plugin: Fix closed ZipFile handles (#341)
+
+`unihan_quick_zip` and `unihan_mock_zip` fixtures were returning closed `ZipFile` handles, making them unusable. Now return `UnihanZip` dataclass with proper lazy access.
 
 ### Development
 
@@ -44,6 +97,7 @@ _Add your latest changes from PRs here_
 ### Documentation
 
 - Migrate docs deployment to AWS OIDC authentication and AWS CLI
+- Rewrite `docs/pytest-plugin.md` with new fixture API (#341)
 
 ## unihan-etl 0.38.0 (2025-11-01)
 

--- a/MIGRATION
+++ b/MIGRATION
@@ -20,7 +20,80 @@ Migration and deprecation notes for unihan-etl are here, see {ref}`history` as w
 
 ## Next release
 
-_Notes on the upcoming release will be added here_
+### pytest plugin: Fixture dataclass containers
+
+The pytest plugin fixtures have been redesigned with better type safety and DX.
+Fixtures that previously returned `zipfile.ZipFile` now return dataclass containers.
+
+#### `unihan_quick_zip` and `unihan_mock_zip` return `UnihanZip`
+
+Before:
+
+```python
+def test_example(unihan_mock_zip: zipfile.ZipFile) -> None:
+    # This was broken - ZipFile was closed before return!
+    files = unihan_mock_zip.namelist()  # Would fail
+```
+
+After:
+
+```python
+from unihan_etl.types import UnihanZip
+
+def test_example(unihan_mock_zip: UnihanZip) -> None:
+    # Access path directly
+    assert unihan_mock_zip.exists()
+
+    # Use context manager for open handle
+    with unihan_mock_zip.open() as zf:
+        files = zf.namelist()
+
+    # Or use convenience property
+    files = unihan_mock_zip.namelist
+```
+
+#### New primary fixtures: `unihan_quick` and `unihan_full`
+
+New `UnihanDataset` container fixtures provide unified access to all dataset paths:
+
+```python
+from unihan_etl.types import UnihanDataset
+
+def test_with_dataset(unihan_quick: UnihanDataset) -> None:
+    assert unihan_quick.name == "quick"
+    assert unihan_quick.zip.exists()
+    print(unihan_quick.work_dir)
+    print(unihan_quick.destination)
+```
+
+#### New lazy data fixture: `unihan_quick_data_lazy`
+
+```python
+from unihan_etl.types import UnihanData
+
+def test_lazy_data(unihan_quick_data_lazy: UnihanData) -> None:
+    # Data only loads when accessed
+    expanded = unihan_quick_data_lazy.expanded
+    by_char = unihan_quick_data_lazy.by_char
+```
+
+#### CLI option: `--unihan-cache-dir`
+
+Override the cache directory via command line:
+
+```bash
+pytest --unihan-cache-dir=/tmp/my-cache
+```
+
+#### Marker: `@pytest.mark.unihan_full`
+
+Mark tests requiring the full dataset:
+
+```python
+@pytest.mark.unihan_full
+def test_full_dataset(unihan_full: UnihanDataset, unihan_ensure_full: None) -> None:
+    assert unihan_full.is_ready
+```
 
 <!-- Maintainers, insert migration notes for the next release here -->
 

--- a/MIGRATION
+++ b/MIGRATION
@@ -31,8 +31,9 @@ Before:
 
 ```python
 def test_example(unihan_mock_zip: zipfile.ZipFile) -> None:
-    # This was broken - ZipFile was closed before return!
-    files = unihan_mock_zip.namelist()  # Would fail
+    # ZipFile was closed before return - couldn't read file contents!
+    with unihan_mock_zip.open("Unihan_Readings.txt") as f:
+        content = f.read()  # Would fail - handle closed
 ```
 
 After:

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -75,9 +75,11 @@ def test_lazy_data(unihan_quick_data_lazy: UnihanData) -> None:
 Container for UNIHAN zip file with lazy access:
 
 ```python
+import pathlib
+
 from unihan_etl.types import UnihanZip
 
-def test_zip(unihan_quick_zip: UnihanZip) -> None:
+def test_zip(unihan_quick_zip: UnihanZip, tmp_path: pathlib.Path) -> None:
     # Path access
     assert unihan_quick_zip.path.exists()
     assert unihan_quick_zip.exists()
@@ -89,8 +91,8 @@ def test_zip(unihan_quick_zip: UnihanZip) -> None:
     # Convenience property
     files = unihan_quick_zip.namelist
 
-    # Extract all
-    unihan_quick_zip.extract(some_path)
+    # Extract to destination
+    unihan_quick_zip.extract(tmp_path)
 ```
 
 ### UnihanDataset

--- a/docs/pytest-plugin.md
+++ b/docs/pytest-plugin.md
@@ -2,7 +2,7 @@
 
 # `pytest` plugin
 
-Download and reuse UNIHAN.zip on the fly in [pytest].
+Download and reuse UNIHAN data on the fly in [pytest].
 
 ```{module} unihan_etl.pytest_plugin
 
@@ -12,74 +12,205 @@ Download and reuse UNIHAN.zip on the fly in [pytest].
 
 ## Usage
 
-Install `unihan-etl` via the python package manager of your choosing, e.g.
-
-Using uv to add it to your project:
+Install `unihan-etl` via the package manager of your choosing:
 
 ```console
 $ uv add unihan-etl
 ```
 
-Run it without installing via uvx:
+The pytest plugin is automatically detected via pytest, and fixtures are available.
 
-```console
-$ uvx unihan-etl
+## Quick Start
+
+The plugin provides two dataset tiers:
+
+- **quick**: Bundled subset (~140KB), no network required - use for unit tests
+- **full**: Complete UNIHAN dataset (~20MB), downloads once - use for integration tests
+
+### Basic Usage
+
+```python
+from unihan_etl.types import UnihanDataset, UnihanZip
+
+def test_quick_dataset(unihan_quick: UnihanDataset) -> None:
+    """Test with the quick (bundled) dataset."""
+    assert unihan_quick.name == "quick"
+    assert unihan_quick.zip.exists()
+
+    # Access zip contents
+    with unihan_quick.zip.open() as zf:
+        assert "Unihan_Readings.txt" in zf.namelist()
 ```
 
-Install it system-wide with pip:
+### With Extracted Data
 
-```console
-$ pip install unihan-etl
+```python
+def test_with_data(
+    unihan_quick: UnihanDataset,
+    unihan_ensure_quick: None,  # Ensures data is extracted
+) -> None:
+    """Test with extracted data."""
+    assert unihan_quick.is_ready
+    assert unihan_quick.destination.exists()
 ```
 
-The pytest plugin will automatically be detected via pytest, and the fixtures will be added.
+### Lazy Data Loading
 
-## Fixtures
+```python
+from unihan_etl.types import UnihanData
 
-`pytest-unihan` works through providing {ref}`pytest fixtures <pytest:fixtures-api>` - so read up on
-those!
+def test_lazy_data(unihan_quick_data_lazy: UnihanData) -> None:
+    """Data only loads when accessed."""
+    # Not loaded yet...
+    expanded = unihan_quick_data_lazy.expanded  # Loads on access
+    by_char = unihan_quick_data_lazy.by_char    # Cached after first load
 
-The plugin's fixtures guarantee downloading, and then reusing UNIHAN.zip every
-test without needing to redownload.
+    assert "丘" in by_char or len(expanded) > 0
+```
 
-(recommended-fixtures)=
+## Dataset Types
 
-## Recommended fixtures
+### UnihanZip
 
-These fixtures are automatically used when the plugin is enabled and `pytest` is run.
+Container for UNIHAN zip file with lazy access:
 
-- Creating temporary, test directories for:
-  - `/home/` ({func}`home_path`)
-  - `/home/${user}` ({func}`user_path`)
-- Setting your home directory
-  - Patch `$HOME` to point to {func}`user_path` ({func}`set_home`)
+```python
+from unihan_etl.types import UnihanZip
 
-## Bootstrapping pytest in your `conftest.py`
+def test_zip(unihan_quick_zip: UnihanZip) -> None:
+    # Path access
+    assert unihan_quick_zip.path.exists()
+    assert unihan_quick_zip.exists()
 
-The most common scenario is you will want to configure the above fixtures with `autouse`.
+    # Context manager for open handle
+    with unihan_quick_zip.open() as zf:
+        files = zf.namelist()
 
-_Why doesn't the plugin automatically add them?_ It's part of being a decent pytest plugin and
-python package: explicitness.
+    # Convenience property
+    files = unihan_quick_zip.namelist
 
-(set_home)=
+    # Extract all
+    unihan_quick_zip.extract(some_path)
+```
 
-### Setting a temporary home directory
+### UnihanDataset
+
+Complete dataset container with all paths:
+
+```python
+from unihan_etl.types import UnihanDataset
+
+def test_dataset(unihan_quick: UnihanDataset) -> None:
+    assert unihan_quick.name in ("quick", "full")
+    assert isinstance(unihan_quick.zip, UnihanZip)
+    assert isinstance(unihan_quick.work_dir, pathlib.Path)
+    assert isinstance(unihan_quick.destination, pathlib.Path)
+    assert isinstance(unihan_quick.is_ready, bool)
+```
+
+### UnihanData
+
+Lazy-loaded data container:
+
+```python
+from unihan_etl.types import UnihanData
+
+def test_data(unihan_quick_data_lazy: UnihanData) -> None:
+    # Properties load data on first access
+    normalized = unihan_quick_data_lazy.normalized  # Raw normalized data
+    expanded = unihan_quick_data_lazy.expanded      # Expanded delimited fields
+    by_char = unihan_quick_data_lazy.by_char        # Dict keyed by character
+```
+
+## CLI Options
+
+### `--unihan-cache-dir`
+
+Override the cache directory:
+
+```console
+$ pytest --unihan-cache-dir=/tmp/my-cache
+```
+
+## Markers
+
+### `@pytest.mark.unihan_full`
+
+Mark tests that require the full UNIHAN dataset:
 
 ```python
 import pytest
+from unihan_etl.types import UnihanDataset
 
-@pytest.fixture(autouse=True)
-def setup(
-    set_home: None,
-):
-    pass
+@pytest.mark.unihan_full
+def test_full_dataset(
+    unihan_full: UnihanDataset,
+    unihan_ensure_full: None,
+) -> None:
+    """This test requires the full dataset (~26MB download)."""
+    assert unihan_full.is_ready
 ```
 
-## See examples
+## Fixture Reference
 
-View unihan-etl's own [tests/](https://github.com/cihai/unihan-etl/tree/master/tests)
+### Primary Fixtures
 
-## API reference
+| Fixture | Scope | Returns | Description |
+|---------|-------|---------|-------------|
+| `unihan_quick` | session | `UnihanDataset` | Quick dataset container |
+| `unihan_full` | session | `UnihanDataset` | Full dataset container |
+| `unihan_quick_zip` | session | `UnihanZip` | Quick dataset zip container |
+| `unihan_ensure_quick` | session | `None` | Extracts quick dataset |
+| `unihan_ensure_full` | session | `None` | Downloads and extracts full dataset |
+| `unihan_quick_data_lazy` | session | `UnihanData` | Lazy-loaded quick data |
+
+### Path Fixtures
+
+| Fixture | Scope | Returns | Description |
+|---------|-------|---------|-------------|
+| `unihan_cache_path` | session | `Path` | Cache directory (overridable) |
+| `unihan_fixture_root` | session | `Path` | Root for fixture data |
+| `unihan_quick_path` | session | `Path` | Quick dataset directory |
+| `unihan_full_path` | session | `Path` | Full dataset directory |
+
+### Options/Packager Fixtures
+
+| Fixture | Scope | Returns | Description |
+|---------|-------|---------|-------------|
+| `unihan_quick_options` | session | `UnihanOptions` | Options for quick dataset |
+| `unihan_full_options` | session | `UnihanOptions` | Options for full dataset |
+| `unihan_quick_packager` | session | `Packager` | Packager for quick dataset |
+| `unihan_full_packager` | session | `Packager` | Packager for full dataset |
+
+### Data Fixtures
+
+| Fixture | Scope | Returns | Description |
+|---------|-------|---------|-------------|
+| `unihan_quick_normalized_data` | session | `UntypedNormalizedData` | Normalized quick data |
+| `unihan_quick_expanded_data` | session | `ExpandedExport` | Expanded quick data |
+| `unihan_quick_data` | session | `str` | Raw UNIHAN excerpt |
+
+## Overriding Fixtures
+
+Override `unihan_cache_path` to customize cache location:
+
+```python
+# conftest.py
+import pathlib
+import pytest
+
+@pytest.fixture(scope="session")
+def unihan_cache_path() -> pathlib.Path:
+    """Use a custom cache location."""
+    return pathlib.Path("/my/custom/cache")
+```
+
+## See Also
+
+- [unihan-etl tests](https://github.com/cihai/unihan-etl/tree/master/tests) - Example usage
+- [MIGRATION](https://github.com/cihai/unihan-etl/blob/master/MIGRATION) - Breaking changes
+
+## API Reference
 
 ```{eval-rst}
 .. automodule:: unihan_etl.pytest_plugin

--- a/src/unihan_etl/types.py
+++ b/src/unihan_etl/types.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
+import pathlib
 import sys
 import typing as t
-from collections.abc import Mapping, Sequence
+import zipfile
+from collections.abc import Generator, Mapping, Sequence
 
 if t.TYPE_CHECKING:
-    import pathlib
     from http.client import HTTPMessage
     from os import PathLike
     from typing import TypeAlias
     from urllib.request import _DataType
+
+    from unihan_etl.core import Packager
 
 StrPath: TypeAlias = t.Union[str, "PathLike[str]"]
 """:class:`os.PathLike` or :class:`str`
@@ -60,6 +64,242 @@ class Options:
     prune_empty: bool
     cache: bool
     log_level: LogLevel
+
+
+# ---------------------------------------------------------------------------
+# Pytest fixture types
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class UnihanZip:
+    """Container for UNIHAN zip file with lazy access.
+
+    Provides safe access to zip file contents without leaving handles open.
+    Use the :meth:`open` context manager when you need to work with the
+    zip file directly.
+
+    Examples
+    --------
+    >>> zip_container = UnihanZip(pathlib.Path("/path/to/Unihan.zip"))
+    >>> zip_container.path
+    PosixPath('/path/to/Unihan.zip')
+    >>> with zip_container.open() as zf:
+    ...     print(zf.namelist())  # doctest: +SKIP
+    ['Unihan_Readings.txt', ...]
+    """
+
+    path: pathlib.Path
+
+    @contextlib.contextmanager
+    def open(
+        self,
+        mode: t.Literal["r", "w", "a", "x"] = "r",
+    ) -> Generator[zipfile.ZipFile, None, None]:
+        """Open the zip file as a context manager.
+
+        Parameters
+        ----------
+        mode : Literal["r", "w", "a", "x"], optional
+            Mode to open the zip file, by default 'r'
+
+        Yields
+        ------
+        zipfile.ZipFile
+            Open zip file handle
+        """
+        with zipfile.ZipFile(self.path, mode) as zf:
+            yield zf
+
+    @property
+    def namelist(self) -> list[str]:
+        """Get list of files in the zip archive.
+
+        Returns
+        -------
+        list[str]
+            Names of files in the archive
+        """
+        with self.open() as zf:
+            return zf.namelist()
+
+    def extract(self, dest: pathlib.Path) -> None:
+        """Extract all files to destination directory.
+
+        Parameters
+        ----------
+        dest : pathlib.Path
+            Directory to extract files to
+        """
+        with self.open() as zf:
+            zf.extractall(dest)
+
+    def exists(self) -> bool:
+        """Check if the zip file exists.
+
+        Returns
+        -------
+        bool
+            True if the zip file exists on disk
+        """
+        return self.path.exists()
+
+
+@dataclasses.dataclass(frozen=True)
+class UnihanDataset:
+    """Complete UNIHAN dataset container with paths and metadata.
+
+    This is the primary fixture type for working with UNIHAN test data.
+    It provides access to all paths and lazy data loading.
+
+    Attributes
+    ----------
+    name : Literal["quick", "full"]
+        Dataset type identifier
+    root : pathlib.Path
+        Root directory for this dataset
+    zip : UnihanZip
+        Zip file container with lazy access methods
+    work_dir : pathlib.Path
+        Working directory for extracted files
+    destination : pathlib.Path
+        Path to exported CSV/JSON/YAML output
+
+    Examples
+    --------
+    >>> dataset = UnihanDataset(
+    ...     name="quick",
+    ...     root=pathlib.Path("/cache/quick"),
+    ...     zip=UnihanZip(pathlib.Path("/cache/quick/Unihan.zip")),
+    ...     work_dir=pathlib.Path("/cache/quick/work"),
+    ...     destination=pathlib.Path("/cache/quick/out/unihan.csv"),
+    ... )
+    >>> dataset.is_ready
+    False
+    """
+
+    name: t.Literal["quick", "full"]
+    root: pathlib.Path
+    zip: UnihanZip
+    work_dir: pathlib.Path
+    destination: pathlib.Path
+
+    @property
+    def is_ready(self) -> bool:
+        """Check if dataset has been extracted and exported.
+
+        Returns
+        -------
+        bool
+            True if destination file exists
+        """
+        return self.destination.exists()
+
+    @property
+    def zip_path(self) -> pathlib.Path:
+        """Convenience accessor for zip file path.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the zip file
+        """
+        return self.zip.path
+
+
+@dataclasses.dataclass
+class UnihanData:
+    """Lazy-loaded UNIHAN data container.
+
+    Provides deferred loading of normalized and expanded UNIHAN data.
+    Data is only loaded when the corresponding property is accessed.
+
+    Attributes
+    ----------
+    packager : Packager
+        The packager instance to load data from
+
+    Examples
+    --------
+    >>> # Data isn't loaded until accessed:
+    >>> data = UnihanData(packager)  # doctest: +SKIP
+    >>> data.normalized  # Loads normalized data  # doctest: +SKIP
+    >>> data.expanded    # Loads expanded data  # doctest: +SKIP
+    """
+
+    packager: Packager
+    _normalized: UntypedNormalizedData | None = dataclasses.field(
+        default=None,
+        repr=False,
+    )
+    _expanded: ExpandedExport | None = dataclasses.field(
+        default=None,
+        repr=False,
+    )
+    _by_char: dict[str, UntypedUnihanData] | None = dataclasses.field(
+        default=None,
+        repr=False,
+    )
+
+    def _load_normalized(self) -> UntypedNormalizedData:
+        """Load normalized data from packager."""
+        from unihan_etl import core
+
+        files = [
+            self.packager.options.work_dir / f
+            for f in self.packager.options.input_files
+            if (self.packager.options.work_dir / f).exists()
+        ]
+        data = core.load_data(files=files)
+        return core.normalize(data, list(self.packager.options.fields))
+
+    @property
+    def normalized(self) -> UntypedNormalizedData:
+        """Get normalized UNIHAN data (lazy-loaded).
+
+        Returns
+        -------
+        UntypedNormalizedData
+            Sequence of normalized UNIHAN records
+        """
+        if self._normalized is None:
+            self._normalized = self._load_normalized()
+        return self._normalized
+
+    @property
+    def expanded(self) -> ExpandedExport:
+        """Get expanded UNIHAN data (lazy-loaded).
+
+        Expands delimited fields into structured lists/dicts.
+
+        Returns
+        -------
+        ExpandedExport
+            Sequence of expanded UNIHAN records
+        """
+        if self._expanded is None:
+            from unihan_etl.core import expand_delimiters
+
+            self._expanded = expand_delimiters(list(self.normalized))
+        return self._expanded
+
+    @property
+    def by_char(self) -> dict[str, UntypedUnihanData]:
+        """Get data indexed by character for fast lookup.
+
+        Returns
+        -------
+        dict[str, UntypedUnihanData]
+            Dictionary mapping characters to their data
+        """
+        if self._by_char is None:
+            self._by_char = {item["char"]: item for item in self.expanded}
+        return self._by_char
+
+
+# ---------------------------------------------------------------------------
+# Protocol types
+# ---------------------------------------------------------------------------
 
 
 class ReportHookFn(t.Protocol):

--- a/tests/test_unihan.py
+++ b/tests/test_unihan.py
@@ -31,22 +31,22 @@ if t.TYPE_CHECKING:
     from collections.abc import Callable
     from urllib.request import _DataType
 
-    from unihan_etl.types import ColumnData, StrPath, UntypedNormalizedData
+    from unihan_etl.types import ColumnData, StrPath, UnihanZip, UntypedNormalizedData
 
 
 log = logging.getLogger(__name__)
 
 
-def test_zip_has_files(unihan_mock_zip: zipfile.ZipFile) -> None:
+def test_zip_has_files(unihan_mock_zip: UnihanZip) -> None:
     """Test zip_has_files() returns when zip file has files contents inside."""
-    assert zip_has_files(["Unihan_Readings.txt"], unihan_mock_zip)
-
-    assert not zip_has_files(["Unihan_Cats.txt"], unihan_mock_zip)
+    with unihan_mock_zip.open() as zf:
+        assert zip_has_files(["Unihan_Readings.txt"], zf)
+        assert not zip_has_files(["Unihan_Cats.txt"], zf)
 
 
 def test_has_valid_zip(
     tmp_path: pathlib.Path,
-    unihan_mock_zip: zipfile.ZipFile,
+    unihan_mock_zip: UnihanZip,
 ) -> None:
     """Test has_valid_zip() returns whether zip file is valid."""
     if UNIHAN_ZIP_PATH.is_file():
@@ -54,9 +54,8 @@ def test_has_valid_zip(
     else:
         assert not core.has_valid_zip(UNIHAN_ZIP_PATH)
 
-    assert unihan_mock_zip.filename is not None
-
-    assert core.has_valid_zip(unihan_mock_zip.filename)
+    assert unihan_mock_zip.exists()
+    assert core.has_valid_zip(unihan_mock_zip.path)
 
     bad_zip = tmp_path / "corrupt.zip"
     bad_zip.write_text("moo", encoding="utf-8")

--- a/tests/test_unihan.py
+++ b/tests/test_unihan.py
@@ -27,7 +27,6 @@ from unihan_etl.test import assert_dict_contains_subset
 from unihan_etl.util import get_fields
 
 if t.TYPE_CHECKING:
-    import zipfile
     from collections.abc import Callable
     from urllib.request import _DataType
 
@@ -100,7 +99,6 @@ def test_get_files() -> None:
 
 def test_download(
     tmp_path: pathlib.Path,
-    unihan_mock_zip: zipfile.ZipFile,
     unihan_mock_zip_path: pathlib.Path,
     unihan_mock_zip_pathname: pathlib.Path,
 ) -> None:
@@ -131,7 +129,6 @@ def test_download(
 
 def test_download_mock(
     tmp_path: pathlib.Path,
-    unihan_mock_zip: zipfile.ZipFile,
     unihan_mock_zip_path: pathlib.Path,
     unihan_mock_test_dir: pathlib.Path,
     unihan_test_options: Options,
@@ -171,7 +168,6 @@ def test_download_mock(
 
 def test_export_format(
     tmp_path: pathlib.Path,
-    unihan_mock_zip: zipfile.ZipFile,
     unihan_mock_zip_path: pathlib.Path,
     unihan_mock_test_dir: pathlib.Path,
     unihan_test_options: Options,
@@ -210,7 +206,6 @@ def test_export_format(
 
 
 def test_extract_zip(
-    unihan_mock_zip: zipfile.ZipFile,
     unihan_mock_zip_path: pathlib.Path,
     tmp_path: pathlib.Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Redesigns the pytest plugin with type-safe dataclass containers for better DX:

- **Fixed critical bug**: `unihan_quick_zip` and `unihan_mock_zip` were returning closed `ZipFile` handles
- **New dataclass types**: `UnihanZip`, `UnihanDataset`, `UnihanData` in `types.py`
- **New primary fixtures**: `unihan_quick` and `unihan_full` returning `UnihanDataset`
- **Lazy data loading**: `unihan_quick_data_lazy` returns `UnihanData` with deferred processing
- **CLI option**: `--unihan-cache-dir` to override cache location
- **Marker**: `@pytest.mark.unihan_full` for tests requiring full dataset

### Breaking Changes

Fixtures that previously returned `zipfile.ZipFile` now return `UnihanZip`:

```python
# Before (broken - ZipFile was closed!)
def test_example(unihan_mock_zip: zipfile.ZipFile) -> None:
    files = unihan_mock_zip.namelist()  # Would fail

# After
def test_example(unihan_mock_zip: UnihanZip) -> None:
    with unihan_mock_zip.open() as zf:
        files = zf.namelist()
```

See `MIGRATION` for full details.

## Test plan

- [x] All 151 tests pass
- [x] mypy passes (19 files)
- [x] ruff check/format passes
- [x] Updated MIGRATION documentation
- [x] Updated docs/pytest-plugin.md