### PR TITLE
docs: Link TypeAlias return types in pytest plugin fixture table

### DIFF
--- a/docs/api/pytest-plugin.md
+++ b/docs/api/pytest-plugin.md
@@ -36,3 +36,9 @@ def setup(
     pass
 ```
 :::
+
+## Types
+
+```{eval-rst}
+.. autodata:: unihan_etl.pytest_plugin.UnihanTestOptions
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,13 @@ import pathlib
 import sys
 import typing as t
 
+if t.TYPE_CHECKING:
+    from docutils import nodes
+    from sphinx import addnodes
+    from sphinx.application import Sphinx
+    from sphinx.domains.python import PythonDomain
+    from sphinx.environment import BuildEnvironment
+
 from gp_sphinx.config import make_linkcode_resolve, merge_sphinx_config
 from pygments import token
 from pygments.lexer import RegexLexer, bygroups as _bygroups
@@ -174,3 +181,33 @@ class TsvLexer(CsvLexer):
 
 
 lexers["tsv"] = TsvLexer()
+
+
+def _on_missing_class_reference(
+    app: Sphinx,
+    env: BuildEnvironment,
+    node: addnodes.pending_xref,
+    contnode: nodes.TextElement,
+) -> nodes.reference | None:
+    if node.get("refdomain") != "py" or node.get("reftype") != "class":
+        return None
+    from sphinx.util.nodes import make_refnode
+
+    py_domain: PythonDomain = env.get_domain("py")  # type: ignore[assignment]
+    target = node.get("reftarget", "")
+    matches = py_domain.find_obj(env, "", "", target, None, 1)
+    if not matches:
+        return None
+    _name, obj_entry = matches[0]
+    return make_refnode(
+        app.builder,
+        node.get("refdoc", ""),
+        obj_entry.docname,
+        obj_entry.node_id,
+        contnode,
+    )
+
+
+def setup(app: Sphinx) -> None:
+    """Connect missing-reference handler to resolve py:data as :class: links."""
+    app.connect("missing-reference", _on_missing_class_reference)

--- a/src/unihan_etl/pytest_plugin.py
+++ b/src/unihan_etl/pytest_plugin.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import typing as t
 import zipfile
+from collections.abc import Mapping
 
 import pytest
 from appdirs import AppDirs as BaseAppDirs
@@ -386,7 +387,6 @@ def unihan_zshrc(unihan_user_path: pathlib.Path) -> pathlib.Path:
 
 
 if t.TYPE_CHECKING:
-    from collections.abc import Mapping
     from typing import TypeAlias
 
     from unihan_etl.types import (
@@ -395,7 +395,12 @@ if t.TYPE_CHECKING:
         UntypedNormalizedData,
     )
 
-    UnihanTestOptions: TypeAlias = UnihanOptions | Mapping[str, t.Any]
+UnihanTestOptions: TypeAlias = UnihanOptions | Mapping[str, t.Any]
+"""Options accepted by :fixture:`unihan_test_options`.
+
+Either a fully-configured :class:`~unihan_etl.options.Options` dataclass or a
+plain mapping of keyword arguments.
+"""
 
 
 @pytest.fixture

--- a/src/unihan_etl/pytest_plugin.py
+++ b/src/unihan_etl/pytest_plugin.py
@@ -387,6 +387,7 @@ def unihan_zshrc(unihan_user_path: pathlib.Path) -> pathlib.Path:
 
 if t.TYPE_CHECKING:
     from collections.abc import Mapping
+    from typing import TypeAlias
 
     from unihan_etl.types import (
         ColumnData,
@@ -394,9 +395,11 @@ if t.TYPE_CHECKING:
         UntypedNormalizedData,
     )
 
+    UnihanTestOptions: TypeAlias = UnihanOptions | Mapping[str, t.Any]
+
 
 @pytest.fixture
-def unihan_test_options() -> UnihanOptions | Mapping[str, t.Any]:
+def unihan_test_options() -> UnihanTestOptions:
     """Return UnihanOptions for test data."""
     return UnihanOptions(input_files=["Unihan_Readings.txt"])
 

--- a/src/unihan_etl/types.py
+++ b/src/unihan_etl/types.py
@@ -26,19 +26,23 @@ StrPath: TypeAlias = t.Union[str, "PathLike[str]"]
 LogLevel = t.Literal["NOTSET", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 # Column data
-ColumnData = Sequence[str]
+ColumnData: TypeAlias = Sequence[str]
+"""Sequence of UNIHAN field name strings."""
+
 ColumnDataTuple = tuple[str, ...]
 
 # In situ
 UntypedUnihanData = Mapping[str, t.Any]
 
-UntypedNormalizedData = Sequence[UntypedUnihanData]
+UntypedNormalizedData: TypeAlias = Sequence[UntypedUnihanData]
+"""Normalized UNIHAN data as a sequence of field-value mappings."""
 
 # Export w/ listify()
 ListifiedExport = list[list[str]]
 
 # Export w/ listify() -> expand_delimiters()
-ExpandedExport = Sequence[Mapping[str, t.Any]]
+ExpandedExport: TypeAlias = Sequence[Mapping[str, t.Any]]
+"""Expanded UNIHAN export with multi-value delimiters resolved."""
 
 # Valid output formats
 UnihanFormats = t.Literal["json", "csv", "yaml", "python"]


### PR DESCRIPTION
## Problem

Return types in the pytest plugin fixture summary table — `ColumnData`, `ExpandedExport`, `UntypedNormalizedData`, `UnihanTestOptions` — showed as plain unlinked text instead of cross-reference links to their type definitions.

Three separate issues compounded:

**TypeAliases missing from the Sphinx inventory.** `automodule :members:` silently skips bare assignments like `ColumnData = Sequence[str]` when the value's `__module__` belongs to another package (`collections.abc` in this case). The static analyser only overrides that filter when the name has a docstring. No docstring → no `py:data` entry → nothing to link to.

**`:class:` xrefs don't search `py:data`.** `sphinx-autodoc-pytest-fixtures` wraps every fixture return-type name in a `:class:` cross-reference. Sphinx's Python domain only searches `py:class` and `py:exception` for `:class:` lookups — TypeAliases land as `py:data` and are never found, even once they're in the inventory.

**`UnihanTestOptions` was invisible at runtime.** Defined inside `TYPE_CHECKING`, so `get_type_hints()` could not resolve the annotation string, and the extension fell back to showing the expanded union type rather than the alias name.

## Solution

Add docstrings to the three TypeAliases in `types.py` so the static analyser includes them in the inventory.

Add a `missing-reference` handler in `conf.py` that falls back from `py:class` lookup to a full Python-domain search, allowing `py:data` entries to resolve when `:class:` fails. Cast `get_domain("py")` to `PythonDomain` so `find_obj()` is type-safe.

Move `UnihanTestOptions` to module level (valid at runtime on Python 3.10+ as a native union expression) and add it to a `## Types` section in the plugin docs page — same pattern as libvcs — so it has both a docstring-driven inventory entry and a stable anchor target on the page.

## Test plan

- `uv run mypy src tests` passes
- `uv run py.test` passes
- `docs/api/pytest-plugin/` — all four type names render as clickable links in the fixture table and fixture signatures