### PR TITLE
fix(docs): restore gp-sphinx FOWT prevention

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,15 @@ Then run `unihan-etl@next`.
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Bug fixes
+
+- Fix dark-theme flash when light theme is selected — the docs
+  `conf.py` was overriding gp-sphinx's `setup()` callback, so the
+  inline FOWT-prevention `<script>` never landed in `<head>`. Chain
+  the gp-sphinx setup explicitly so the script (and the
+  `spa-nav.js` / copybutton / MyST-lexer hooks) register correctly
+  (#357)
+
 ### Documentation
 
 - Visual improvements to API docs from [gp-sphinx](https://gp-sphinx.git-pull.com)-based Sphinx packages (#354)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,8 @@ conf = merge_sphinx_config(
     html_extra_path=["manifest.json"],
     rediraffe_redirects="redirects.txt",
 )
+
+_gp_setup = conf.pop("setup")
 globals().update(conf)
 
 
@@ -210,5 +212,14 @@ def _on_missing_class_reference(
 
 
 def setup(app: Sphinx) -> None:
-    """Connect missing-reference handler to resolve py:data as :class: links."""
+    """Chain gp-sphinx setup() and connect the missing-reference handler.
+
+    ``_gp_setup`` is the callback ``gp_sphinx.config.merge_sphinx_config``
+    returns; it registers the FOWT-prevention head injection,
+    ``spa-nav.js``, the copy-button bridge, the ``remove_tabs_js``
+    cleanup, and the MyST Pygments lexers. Without this chain those
+    hooks never register and the docs site flashes the wrong theme
+    before settling on the user's preference.
+    """
+    _gp_setup(app)
     app.connect("missing-reference", _on_missing_class_reference)


### PR DESCRIPTION
Restores the inline `<script>` that hides `<body>` until the resolved theme is applied — without it, the page renders with the default theme briefly before flipping to the user's preference, showing as a dark→light flash on light-theme loads.

## Root cause

`docs/conf.py` defined `def setup(app)` after `globals().update(conf)`. Python module-namespace order means the user's `setup` silently shadowed the one `gp_sphinx.config.merge_sphinx_config()` returns. With gp-sphinx's `setup` never running, four hooks the theme relies on never registered:

- `_inject_fowt_prevention` head-injection (the visible flicker bug)
- `_inject_copybutton_bridge` selector script
- `js/spa-nav.js` SPA-navigation script
- `remove_tabs_js` build-finished cleanup
- `myst` / `myst-md` Pygments lexers

## Fix

Mirror the chain pattern already in use at [`vcspull/docs/conf.py`](https://github.com/vcs-python/vcspull/blob/master/docs/conf.py): pop `conf["setup"]` into `_gp_setup` before `globals().update(conf)`, then call `_gp_setup(app)` as the first statement of the user's `setup(app)`.

## Verification

Local `just build-docs` produces a `<head>` containing both:

- `<style>html.gp-sphinx-theme-pending body:not([data-theme]){visibility:hidden}</style>`
- `<script data-cfasync="false">(function(){var t=localStorage.getItem("theme")||"auto";...})()</script>`

These were absent from the live site before this PR. Grep proof on the local build: `gp-sphinx-theme-pending` count goes from `0` → `2`.
