### PR TITLE
Fix UNIHAN cache correctness: download gate and pytest fixtures

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,9 +38,25 @@ _Notes on the upcoming release will go here._
 
 _Add your latest changes from PRs here_
 
+### Fixes
+
+#### Corrupt or custom-named cached zips are re-fetched instead of crashing (#360)
+
+{meth}`unihan_etl.core.Packager.download` now treats a cached UNIHAN archive as reusable only when it is a *valid* zip, rather than when a file merely exists. A corrupt or truncated cache is re-downloaded automatically instead of being handed to extraction (which previously failed with `zipfile.BadZipFile`), and a non-default `zip_path` filename is respected instead of a hardcoded `Unihan.zip`.
+
+### Documentation
+
+#### `--no-cache` documents only the zip cache (#360)
+
+The `unihan-etl export` `--no-cache` help no longer claims it caches "CSV outputs"; caching governs only the downloaded UNIHAN zip and its extraction, which the help now states accurately.
+
 ### Development
 
 The parametrized field-expansion tests now follow the project's typed `NamedTuple` case convention (a `test_id`-led fixture with `ids=` derived from it) already used across the rest of the suite, so expansion test failures report named scenarios instead of positional ids. An unused CLI color-mode test fixture was also removed.
+
+The bundled quick-dataset pytest fixtures now rebuild their cached zip when a source data file changes (detected via CRC32), so edits to the quick UNIHAN fixtures take effect without manually clearing `.unihan_cache`. The zip fixtures also yield an open, reusable archive handle (closed on teardown) instead of an already-closed one.
+
+The bundled pytest fixtures are now safe under `pytest-xdist`: writes to the shared `.unihan_cache` are serialized across workers with an inter-process lock (a no-op in single-process runs), `pytest-xdist` and `filelock` are available as optional test dependencies, and a `just test-dist` target runs the suite in parallel.
 
 ## unihan-etl 0.42.0 (2026-06-28)
 

--- a/justfile
+++ b/justfile
@@ -17,6 +17,11 @@ default:
 test *args:
     uv run py.test {{ args }}
 
+# Run tests in parallel with pytest-xdist
+[group: 'test']
+test-dist *args:
+    uv run py.test -n auto {{ args }}
+
 # Run tests then start continuous testing with pytest-watcher
 [group: 'test']
 start:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ Documentation = "https://unihan-etl.git-pull.com"
 Repository = "https://github.com/cihai/unihan-etl"
 Changes = "https://github.com/cihai/unihan-etl/blob/master/CHANGES"
 
+[project.optional-dependencies]
+xdist = [
+  "pytest-xdist",
+  "filelock",
+]
+
 [dependency-groups]
 dev = [
   # Docs
@@ -79,6 +85,8 @@ dev = [
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",
+  "pytest-xdist",
+  "filelock",
   # Coverage
   "codecov",
   "coverage",
@@ -108,6 +116,8 @@ testing = [
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",
+  "pytest-xdist",
+  "filelock",
 ]
 coverage =[
   "codecov",

--- a/src/unihan_etl/cli/export.py
+++ b/src/unihan_etl/cli/export.py
@@ -132,7 +132,7 @@ def create_export_subparser(
         "--no-cache",
         dest="cache",
         action="store_false",
-        help="Don't cache the UNIHAN zip file or CSV outputs.",
+        help="Don't reuse the cached UNIHAN zip (force re-download and re-extract).",
     )
     parser.add_argument(
         "-f",

--- a/src/unihan_etl/core.py
+++ b/src/unihan_etl/core.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import dataclasses
 import fileinput
+import functools
 import json
 import logging
 import pathlib
@@ -211,8 +212,33 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
+@functools.lru_cache(maxsize=256)
+def _zip_integrity_ok(zip_path: str, mtime_ns: int, size: int) -> bool:
+    """Return True if the zip is structurally valid and every member's CRC passes.
+
+    Memoized on the file's ``(path, mtime_ns, size)`` fingerprint so the
+    expensive :meth:`zipfile.ZipFile.testzip` (which decompresses every member)
+    runs once per file state -- repeat checks of an unchanged archive are free.
+    The ``mtime_ns``/``size`` args are the cache key, not used directly.
+    """
+    if not zipfile.is_zipfile(zip_path):
+        log.info("Not a valid zip: %s", zip_path)
+        return False
+    with zipfile.ZipFile(zip_path) as zf:
+        bad_member = zf.testzip()
+    if bad_member is not None:
+        log.info("Zip member failed CRC check: %s", bad_member)
+        return False
+    log.info("Exists, is valid zip: %s", zip_path)
+    return True
+
+
 def has_valid_zip(zip_path: StrPath) -> bool:
-    """Return True if valid zip exists.
+    """Return True if a valid zip exists at ``zip_path``.
+
+    The structural and member-CRC checks are memoized on the file's
+    ``(path, mtime, size)`` fingerprint, so repeated calls on an unchanged
+    archive only pay a ``stat`` rather than re-decompressing the whole zip.
 
     Parameters
     ----------
@@ -231,11 +257,8 @@ def has_valid_zip(zip_path: StrPath) -> bool:
         log.info("Exists, but is not a file: %s", zip_path)
         return False
 
-    if zipfile.is_zipfile(zip_path):
-        log.info("Exists, is valid zip: %s", zip_path)
-        return True
-    log.info("Not a valid zip: %s", zip_path)
-    return False
+    st = zip_path.stat()
+    return _zip_integrity_ok(str(zip_path), st.st_mtime_ns, st.st_size)
 
 
 def zip_has_files(files: list[str], zip_file: zipfile.ZipFile) -> bool:
@@ -287,13 +310,7 @@ def download(
     if not data_dir.exists():
         data_dir.mkdir(parents=True, exist_ok=True)
 
-    def no_unihan_files_exist() -> bool:
-        return not data_dir.match("Unihan*.txt")
-
-    def not_downloaded() -> bool:
-        return not (data_dir / "Unihan.zip").exists()
-
-    if (no_unihan_files_exist() and not_downloaded()) or not cache:
+    if not has_valid_zip(dest) or not cache:
         log.info("Downloading Unihan.zip...")
         log.info("%s to %s", url, dest)
         if pathlib.Path(url).is_file():

--- a/src/unihan_etl/core.py
+++ b/src/unihan_etl/core.py
@@ -181,7 +181,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--no-cache",
         dest="cache",
         action="store_false",
-        help=("Don't cache the UNIHAN zip file or CSV outputs."),
+        help="Don't reuse the cached UNIHAN zip (force re-download and re-extract).",
     )
     parser.add_argument(
         "-f",

--- a/src/unihan_etl/pytest_plugin.py
+++ b/src/unihan_etl/pytest_plugin.py
@@ -7,9 +7,11 @@ import getpass
 import logging
 import os
 import pathlib
+import shutil
 import typing as t
 import zipfile
-from collections.abc import Mapping
+import zlib
+from collections.abc import Generator, Mapping
 
 import pytest
 from appdirs import AppDirs as BaseAppDirs
@@ -31,6 +33,44 @@ DATA_FIXTURE_PATH = UNIHAN_ETL_PATH / "data_files"
 QUICK_FIXTURE_PATH = DATA_FIXTURE_PATH / "quick"
 
 app_dirs = AppDirs(_app_dirs=BaseAppDirs("pytest-cihai", "cihai team"))
+
+
+def _cache_lock(
+    config: pytest.Config,
+    basetemp: pathlib.Path,
+) -> contextlib.AbstractContextManager[t.Any]:
+    """Return a context manager serializing shared ``.unihan_cache`` writes.
+
+    Off xdist (no ``workerinput`` on the config) this is a no-op
+    :func:`contextlib.nullcontext`. Under an xdist worker it is an inter-process
+    :class:`filelock.FileLock` on the shared base temp dir, so concurrent workers
+    build the cache one at a time. ``filelock`` is imported lazily here so the
+    plugin still loads for downstream consumers that do not depend on it.
+    """
+    if not hasattr(config, "workerinput"):
+        return contextlib.nullcontext()
+    try:
+        from filelock import FileLock
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional test extra
+        msg = "filelock is required to run these fixtures under pytest-xdist"
+        raise ModuleNotFoundError(msg) from exc
+
+    return FileLock(str(basetemp / "unihan_cache.lock"))
+
+
+@pytest.fixture(scope="session")
+def unihan_cache_lock(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> contextlib.AbstractContextManager[t.Any]:
+    """Serialize shared ``.unihan_cache`` writes across xdist workers.
+
+    A no-op in single-process runs; under xdist it locks on the shared base temp
+    so only one worker (re)builds the cache while the others wait and reuse it.
+    One lock deliberately covers both the quick and full datasets: a session
+    bootstraps both, so per-dataset locks would not reduce contention.
+    """
+    return _cache_lock(request.config, tmp_path_factory.getbasetemp().parent)
 
 
 @pytest.fixture(scope="session")
@@ -87,6 +127,7 @@ def unihan_ensure_full(
     unihan_full_path: pathlib.Path,
     unihan_full_options: UnihanOptions,
     unihan_full_packager: Packager,
+    unihan_cache_lock: contextlib.AbstractContextManager[t.Any],
 ) -> None:
     """Download and extract "full" UNIHAN, return UnihanOptions.
 
@@ -170,10 +211,10 @@ def unihan_ensure_full(
         >>> result.assert_outcomes(passed=1)
     """
     pkgr = Packager(unihan_full_options)
-    pkgr.download()
-
-    if not pkgr.options.destination.exists():
-        pkgr.export()
+    with unihan_cache_lock:
+        pkgr.download()
+        if not pkgr.options.destination.exists():
+            pkgr.export()
 
 
 @pytest.fixture(scope="session")
@@ -189,39 +230,129 @@ def unihan_quick_zip_path(unihan_quick_path: pathlib.Path) -> pathlib.Path:
 
 
 @pytest.fixture(scope="session")
+def unihan_quick_work_path(unihan_quick_path: pathlib.Path) -> pathlib.Path:
+    """Return the "quick" dataset extraction (work) directory."""
+    return unihan_quick_path / "work"
+
+
+@pytest.fixture(scope="session")
+def unihan_quick_out_path(unihan_quick_path: pathlib.Path) -> pathlib.Path:
+    """Return the "quick" dataset export (out) directory."""
+    return unihan_quick_path / "out"
+
+
+def _quick_zip_is_stale(
+    zip_path: pathlib.Path,
+    source_files: list[pathlib.Path],
+) -> bool:
+    """Return True if the cached quick zip is missing, invalid, or out of date.
+
+    Staleness is bidirectional and content-aware: the cache is stale when the
+    archive is missing or not a valid zip, when its member set differs from the
+    source set (a file added or removed), or when any source file's content
+    differs from the archived member by CRC32. zipfile stores a CRC per member,
+    so no sidecar hash file is needed.
+    """
+    if not zip_path.is_file() or not zipfile.is_zipfile(zip_path):
+        return True
+    with zipfile.ZipFile(zip_path) as zf:
+        if set(zf.namelist()) != {source.name for source in source_files}:
+            return True
+        for source in source_files:
+            archived_crc = zf.getinfo(source.name).CRC
+            if archived_crc != zlib.crc32(source.read_bytes()) & 0xFFFFFFFF:
+                return True
+    return False
+
+
+def _sync_quick_zip(
+    zip_path: pathlib.Path,
+    source_files: list[pathlib.Path],
+) -> bool:
+    """Build or refresh the quick-dataset zip; return True if it was (re)built.
+
+    Rewrites the whole archive whenever it is stale -- append mode cannot replace
+    or drop a member. The archive is written to a sibling temp file and atomically
+    moved into place, so a reader never observes a half-written zip. Returns False
+    when the cache is already current, so callers can skip invalidating derived
+    artifacts.
+    """
+    if not _quick_zip_is_stale(zip_path, source_files):
+        return False
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = zip_path.parent / (zip_path.name + ".tmp")
+    with zipfile.ZipFile(tmp_path, "w") as zf:
+        for source in source_files:
+            zf.write(source, source.name)
+    tmp_path.replace(zip_path)
+    return True
+
+
+def _sync_quick_dataset(
+    zip_path: pathlib.Path,
+    source_files: list[pathlib.Path],
+    work_dir: pathlib.Path,
+    out_dir: pathlib.Path,
+) -> bool:
+    """Sync the quick zip and, on a rebuild, drop the derived work/out layers.
+
+    Returns True when the zip was rebuilt (and the derived directories cleared so
+    extraction and export regenerate), False when the cache was already current.
+    """
+    rebuilt = _sync_quick_zip(zip_path, source_files)
+    if rebuilt:
+        shutil.rmtree(work_dir, ignore_errors=True)
+        shutil.rmtree(out_dir, ignore_errors=True)
+    return rebuilt
+
+
+@pytest.fixture(scope="session")
 def unihan_quick_zip(
-    unihan_quick_path: pathlib.Path,
     unihan_quick_zip_path: pathlib.Path,
     unihan_quick_fixture_files: list[pathlib.Path],
-) -> zipfile.ZipFile:
-    """Return zip file for "quick" test data set."""
-    files = []
-    for f in unihan_quick_fixture_files:
-        files += [f]
+    unihan_quick_work_path: pathlib.Path,
+    unihan_quick_out_path: pathlib.Path,
+    unihan_cache_lock: contextlib.AbstractContextManager[t.Any],
+) -> Generator[zipfile.ZipFile, None, None]:
+    """Yield the "quick" test data set zip, rebuilding it when sources change.
 
-    with contextlib.suppress(FileExistsError):
-        unihan_quick_zip_path.parent.mkdir(parents=True)
+    The cached archive is refreshed (by CRC32) whenever a bundled quick source
+    file changes, so edits propagate without manually clearing ``.unihan_cache``.
+    On a rebuild the derived ``work/`` and ``out/`` artifacts are cleared so
+    :class:`~unihan_etl.core.Packager` re-extracts and re-exports. The yielded
+    handle is open for reading and closed on teardown.
 
-    zf = zipfile.ZipFile(unihan_quick_zip_path, "a")
-    for _f in unihan_quick_fixture_files:
-        if _f.name not in zf.namelist():
-            zf.write(_f, _f.name)
-    zf.close()
+    Teardown
+    --------
+    Closes the yielded archive handle.
+    """
+    # work/ and out/ are the same fixtures unihan_quick_options uses, so the
+    # cleared dirs always match the extraction/export targets. Cleared on a
+    # rebuild so extract/export regenerate from the refreshed archive.
+    with unihan_cache_lock:
+        _sync_quick_dataset(
+            unihan_quick_zip_path,
+            unihan_quick_fixture_files,
+            unihan_quick_work_path,
+            unihan_quick_out_path,
+        )
 
-    return zf
+    with zipfile.ZipFile(unihan_quick_zip_path) as zf:
+        yield zf
 
 
 @pytest.fixture(scope="session")
 def unihan_quick_options(
-    unihan_quick_path: pathlib.Path,
     unihan_quick_zip: zipfile.ZipFile,
     unihan_quick_zip_path: pathlib.Path,
+    unihan_quick_work_path: pathlib.Path,
+    unihan_quick_out_path: pathlib.Path,
 ) -> UnihanOptions:
     """Return UnihanOptions for "quick" test data set."""
     return UnihanOptions(
-        work_dir=unihan_quick_path / "work",
+        work_dir=unihan_quick_work_path,
         zip_path=unihan_quick_zip_path,
-        destination=unihan_quick_path / "out" / "unihan.csv",
+        destination=unihan_quick_out_path / "unihan.csv",
     )
 
 
@@ -239,6 +370,7 @@ def unihan_ensure_quick(
     unihan_quick_path: pathlib.Path,
     unihan_quick_options: UnihanOptions,
     unihan_quick_packager: Packager,
+    unihan_cache_lock: contextlib.AbstractContextManager[t.Any],
 ) -> None:
     """Return a small, but effective portion of UNIHAN, return a UnihanOptions.
 
@@ -326,10 +458,10 @@ def unihan_ensure_quick(
         >>> result.assert_outcomes(passed=1)
     """
     pkgr = Packager(unihan_quick_options)
-    pkgr.download()
-
-    if not pkgr.options.destination.exists():
-        pkgr.export()
+    with unihan_cache_lock:
+        pkgr.download()
+        if not pkgr.options.destination.exists():
+            pkgr.export()
 
 
 @pytest.fixture(scope="session")
@@ -449,12 +581,18 @@ def unihan_mock_zip_path(
 def unihan_mock_zip(
     unihan_mock_zip_path: pathlib.Path,
     unihan_quick_data: str,
-) -> zipfile.ZipFile:
-    """Return Unihan zipfile."""
-    zf = zipfile.ZipFile(str(unihan_mock_zip_path), "a")
-    zf.writestr("Unihan_Readings.txt", unihan_quick_data.encode("utf-8"))
-    zf.close()
-    return zf
+) -> Generator[zipfile.ZipFile, None, None]:
+    """Yield a mock Unihan zipfile, open for reading and closed on teardown.
+
+    Teardown
+    --------
+    Closes the yielded archive handle.
+    """
+    with zipfile.ZipFile(str(unihan_mock_zip_path), "a") as zf:
+        if "Unihan_Readings.txt" not in zf.namelist():
+            zf.writestr("Unihan_Readings.txt", unihan_quick_data.encode("utf-8"))
+    with zipfile.ZipFile(str(unihan_mock_zip_path)) as zf:
+        yield zf
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,278 @@
+"""Tests for unihan-etl caching: zip staleness invalidation and extract gating."""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import pathlib
+import shutil
+import typing as t
+import zipfile
+
+import pytest
+
+from unihan_etl import core
+from unihan_etl.core import Packager
+from unihan_etl.pytest_plugin import _sync_quick_dataset, _sync_quick_zip
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
+    from http.client import HTTPMessage
+    from urllib.request import _DataType
+
+    from unihan_etl.options import Options
+    from unihan_etl.types import StrPath
+
+
+class StaleZipCase(t.NamedTuple):
+    """Case for :func:`test_quick_zip_staleness_rebuild`."""
+
+    test_id: str
+    mutate: str  # "edit" | "none" | "add" | "remove" | "corrupt"
+    expect_rebuilt: bool
+
+
+STALE_ZIP_CASES: list[StaleZipCase] = [
+    StaleZipCase(test_id="edited_source_rebuilds", mutate="edit", expect_rebuilt=True),
+    StaleZipCase(test_id="unchanged_source_skips", mutate="none", expect_rebuilt=False),
+    StaleZipCase(test_id="added_source_rebuilds", mutate="add", expect_rebuilt=True),
+    StaleZipCase(
+        test_id="removed_source_rebuilds", mutate="remove", expect_rebuilt=True
+    ),
+    StaleZipCase(
+        test_id="corrupt_archive_rebuilds", mutate="corrupt", expect_rebuilt=True
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    StaleZipCase._fields,
+    STALE_ZIP_CASES,
+    ids=[c.test_id for c in STALE_ZIP_CASES],
+)
+def test_quick_zip_staleness_rebuild(
+    test_id: str,
+    mutate: str,
+    expect_rebuilt: bool,
+    tmp_path: pathlib.Path,
+) -> None:
+    """_sync_quick_zip rebuilds the cached zip when the source set changes.
+
+    Staleness is bidirectional and content-aware (CRC32 per member): an edit, an
+    added source, a removed source, or a missing/corrupt archive triggers a
+    rebuild, while an unchanged source set is left untouched.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    readings = src_dir / "Unihan_Readings.txt"
+    readings.write_text("U+3400\tkCantonese\tjau1\n", encoding="utf-8")
+    variants = src_dir / "Unihan_Variants.txt"
+    variants.write_text("U+346E\tkSemanticVariant\tU+34CE\n", encoding="utf-8")
+    sources = [readings, variants]
+    zip_path = tmp_path / "downloads" / "Unihan.zip"
+
+    # Initial build always counts as a (re)build from an absent archive.
+    assert _sync_quick_zip(zip_path, sources) is True
+    with zipfile.ZipFile(zip_path) as zf:
+        assert set(zf.namelist()) == {"Unihan_Readings.txt", "Unihan_Variants.txt"}
+
+    if mutate == "edit":
+        readings.write_text("U+3401\tkCantonese\ttim2\n", encoding="utf-8")
+    elif mutate == "add":
+        numeric = src_dir / "Unihan_NumericValues.txt"
+        numeric.write_text("U+3405\tkOtherNumeric\t5\n", encoding="utf-8")
+        sources = [readings, variants, numeric]
+    elif mutate == "remove":
+        sources = [readings]
+    elif mutate == "corrupt":
+        zip_path.write_bytes(b"not a zip")
+
+    assert _sync_quick_zip(zip_path, sources) is expect_rebuilt
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        if mutate == "edit":
+            assert zf.read("Unihan_Readings.txt").decode("utf-8").startswith("U+3401")
+        elif mutate == "add":
+            assert "Unihan_NumericValues.txt" in names
+        elif mutate == "remove":
+            assert names == {"Unihan_Readings.txt"}
+        elif mutate == "corrupt":
+            assert "Unihan_Readings.txt" in names
+        else:
+            assert names == {"Unihan_Readings.txt", "Unihan_Variants.txt"}
+
+
+def test_sync_quick_dataset_clears_derived_on_rebuild(tmp_path: pathlib.Path) -> None:
+    """A rebuild drops the derived work/ and out/ layers; a no-op leaves them."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    readings = src_dir / "Unihan_Readings.txt"
+    readings.write_text("U+3400\tkCantonese\tjau1\n", encoding="utf-8")
+    sources = [readings]
+    zip_path = tmp_path / "downloads" / "Unihan.zip"
+    work_dir = tmp_path / "work"
+    out_dir = tmp_path / "out"
+
+    def seed_derived() -> tuple[pathlib.Path, pathlib.Path]:
+        work_dir.mkdir(exist_ok=True)
+        out_dir.mkdir(exist_ok=True)
+        work_file = work_dir / "Unihan_Readings.txt"
+        out_file = out_dir / "unihan.csv"
+        work_file.write_text("SENTINEL\n", encoding="utf-8")
+        out_file.write_text("SENTINEL\n", encoding="utf-8")
+        return work_file, out_file
+
+    # Initial build is a rebuild -> derived layers are cleared.
+    work_file, out_file = seed_derived()
+    assert _sync_quick_dataset(zip_path, sources, work_dir, out_dir) is True
+    assert not work_file.exists()
+    assert not out_file.exists()
+
+    # Unchanged sources -> no rebuild -> freshly seeded derived layers survive.
+    work_file, out_file = seed_derived()
+    assert _sync_quick_dataset(zip_path, sources, work_dir, out_dir) is False
+    assert work_file.read_text(encoding="utf-8") == "SENTINEL\n"
+    assert out_file.read_text(encoding="utf-8") == "SENTINEL\n"
+
+
+class PackagerExtractCase(t.NamedTuple):
+    """Case for :func:`test_packager_download_extract_gate`."""
+
+    test_id: str
+    prepopulate: bool  # work_dir already holds the input file (a sentinel)
+    cache: bool
+    expect_overwrite: bool  # extraction overwrites the sentinel
+
+
+PACKAGER_EXTRACT_CASES: list[PackagerExtractCase] = [
+    PackagerExtractCase(
+        test_id="extracts_when_work_empty",
+        prepopulate=False,
+        cache=True,
+        expect_overwrite=True,
+    ),
+    PackagerExtractCase(
+        test_id="skips_extract_when_present_and_cached",
+        prepopulate=True,
+        cache=True,
+        expect_overwrite=False,
+    ),
+    PackagerExtractCase(
+        test_id="reextracts_when_cache_disabled",
+        prepopulate=True,
+        cache=False,
+        expect_overwrite=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    PackagerExtractCase._fields,
+    PACKAGER_EXTRACT_CASES,
+    ids=[c.test_id for c in PACKAGER_EXTRACT_CASES],
+)
+def test_packager_download_extract_gate(
+    test_id: str,
+    prepopulate: bool,
+    cache: bool,
+    expect_overwrite: bool,
+    tmp_path: pathlib.Path,
+    unihan_mock_zip: zipfile.ZipFile,
+    unihan_mock_zip_path: pathlib.Path,
+    unihan_test_options: Options,
+) -> None:
+    """Packager.download extracts only when work_dir lacks inputs or cache is off.
+
+    Guards the gate the quick-zip invalidation relies on: clearing work/ forces a
+    re-extract on the next session run.
+    """
+    sentinel = "SENTINEL\n"
+    zip_path = tmp_path / "downloads" / "Unihan.zip"
+    zip_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(str(unihan_mock_zip_path), str(zip_path))
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    work_file = work_dir / "Unihan_Readings.txt"
+    if prepopulate:
+        work_file.write_text(sentinel, encoding="utf-8")
+
+    download_calls = 0
+
+    def urlretrieve(
+        url: str,
+        filename: StrPath | None = None,
+        reporthook: Callable[[int, int, int], object] | None = None,
+        data: _DataType | None = None,
+    ) -> tuple[str, HTTPMessage]:
+        nonlocal download_calls
+        download_calls += 1
+        shutil.copy(str(unihan_mock_zip_path), str(zip_path))
+        from http.client import HTTPMessage as _HTTPMessage
+
+        return ("", _HTTPMessage())
+
+    packager = Packager(
+        dataclasses.replace(
+            unihan_test_options,
+            source="https://example.invalid/Unihan.zip",
+            zip_path=zip_path,
+            work_dir=work_dir,
+            cache=cache,
+        ),
+    )
+    packager.download(urlretrieve_fn=urlretrieve)
+
+    assert download_calls == (0 if cache else 1)
+    assert work_file.exists()
+    if expect_overwrite:
+        assert work_file.read_text(encoding="utf-8") != sentinel
+    else:
+        assert work_file.read_text(encoding="utf-8") == sentinel
+
+
+def test_mock_zip_fixture_is_open(unihan_mock_zip: zipfile.ZipFile) -> None:
+    """The unihan_mock_zip fixture yields an open, readable archive handle.
+
+    A closed handle raises ``ValueError`` on ``read()``; an open one returns the
+    member bytes.
+    """
+    assert "Unihan_Readings.txt" in unihan_mock_zip.namelist()
+    assert unihan_mock_zip.read("Unihan_Readings.txt")
+
+
+def test_has_valid_zip_memoizes_integrity_check(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unihan_mock_zip: zipfile.ZipFile,
+    unihan_mock_zip_path: pathlib.Path,
+) -> None:
+    """has_valid_zip runs the deep member-CRC check once per file state.
+
+    Repeat checks of an unchanged archive hit the memo (no re-decompress);
+    rewriting the file (new mtime/size) invalidates it and re-verifies.
+    """
+    core._zip_integrity_ok.cache_clear()
+    zip_path = tmp_path / "Unihan.zip"
+    shutil.copy(str(unihan_mock_zip_path), str(zip_path))
+
+    testzip_calls = 0
+    real_testzip = zipfile.ZipFile.testzip
+
+    def counting_testzip(self: zipfile.ZipFile) -> str | None:
+        nonlocal testzip_calls
+        testzip_calls += 1
+        return real_testzip(self)
+
+    monkeypatch.setattr(zipfile.ZipFile, "testzip", counting_testzip)
+
+    assert core.has_valid_zip(zip_path)
+    assert core.has_valid_zip(zip_path)
+    assert core.has_valid_zip(zip_path)
+    assert testzip_calls == 1  # deep check ran once, then memoized
+
+    # A rewrite changes the (mtime, size) fingerprint -> the memo re-verifies.
+    st = zip_path.stat()
+    os.utime(zip_path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    assert core.has_valid_zip(zip_path)
+    assert testzip_calls == 2

--- a/tests/test_unihan.py
+++ b/tests/test_unihan.py
@@ -446,3 +446,154 @@ def test_cli_version(capsys: pytest.CaptureFixture[str], flag: str) -> None:
     captured = capsys.readouterr()
 
     assert __version__ in captured.out
+
+
+class DownloadCacheCase(t.NamedTuple):
+    """Case for :func:`test_download_caching`."""
+
+    test_id: str
+    zip_name: str  # dest filename under <tmp>/downloads/
+    seed_state: str  # "valid" | "corrupt" | "bad_crc" | "absent"
+    cache: bool
+    expect_download: bool
+
+
+DOWNLOAD_CACHE_CASES: list[DownloadCacheCase] = [
+    DownloadCacheCase(
+        test_id="cached_valid_skips",
+        zip_name="Unihan.zip",
+        seed_state="valid",
+        cache=True,
+        expect_download=False,
+    ),
+    DownloadCacheCase(
+        test_id="absent_downloads",
+        zip_name="Unihan.zip",
+        seed_state="absent",
+        cache=True,
+        expect_download=True,
+    ),
+    DownloadCacheCase(
+        test_id="corrupt_redownloads",
+        zip_name="Unihan.zip",
+        seed_state="corrupt",
+        cache=True,
+        expect_download=True,
+    ),
+    DownloadCacheCase(
+        test_id="cache_off_redownloads",
+        zip_name="Unihan.zip",
+        seed_state="valid",
+        cache=False,
+        expect_download=True,
+    ),
+    DownloadCacheCase(
+        test_id="absent_cache_off_downloads",
+        zip_name="Unihan.zip",
+        seed_state="absent",
+        cache=False,
+        expect_download=True,
+    ),
+    DownloadCacheCase(
+        test_id="custom_name_cached_skips",
+        zip_name="Moo.zip",
+        seed_state="valid",
+        cache=True,
+        expect_download=False,
+    ),
+    DownloadCacheCase(
+        test_id="custom_name_bad_crc_redownloads",
+        zip_name="Moo.zip",
+        seed_state="bad_crc",
+        cache=True,
+        expect_download=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    DownloadCacheCase._fields,
+    DOWNLOAD_CACHE_CASES,
+    ids=[c.test_id for c in DOWNLOAD_CACHE_CASES],
+)
+def test_download_caching(
+    test_id: str,
+    zip_name: str,
+    seed_state: str,
+    cache: bool,
+    expect_download: bool,
+    tmp_path: pathlib.Path,
+    unihan_mock_zip: zipfile.ZipFile,
+    unihan_mock_zip_path: pathlib.Path,
+) -> None:
+    """core.download() caches on zip validity, not mere existence or a fixed name.
+
+    A valid cached zip is reused; a missing, corrupt, or cache-disabled dest is
+    (re-)fetched. The dest's real name is honored, not a hardcoded ``Unihan.zip``.
+    """
+    dest = tmp_path / "downloads" / zip_name
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if seed_state == "valid":
+        shutil.copy(str(unihan_mock_zip_path), str(dest))
+    elif seed_state == "corrupt":
+        dest.write_text("not a zip", encoding="utf-8")
+    elif seed_state == "bad_crc":
+        shutil.copy(str(unihan_mock_zip_path), str(dest))
+        zip_bytes = bytearray(dest.read_bytes())
+        zip_bytes[zip_bytes.index(b"jau1")] ^= 0x01
+        dest.write_bytes(zip_bytes)
+
+    download_calls = 0
+
+    def urlretrieve(
+        url: str,
+        filename: StrPath | None = None,
+        reporthook: Callable[[int, int, int], object] | None = None,
+        data: _DataType | None = None,
+    ) -> tuple[str, HTTPMessage]:
+        nonlocal download_calls
+        download_calls += 1
+        shutil.copy(str(unihan_mock_zip_path), str(dest))
+        return ("", HTTPMessage())
+
+    result = core.download(
+        url="https://example.invalid/Unihan.zip",
+        dest=dest,
+        urlretrieve_fn=urlretrieve,
+        cache=cache,
+    )
+
+    assert result == dest
+    assert download_calls == (1 if expect_download else 0)
+    assert core.has_valid_zip(dest)
+
+
+def test_download_returns_usable_path(
+    tmp_path: pathlib.Path,
+    unihan_mock_zip: zipfile.ZipFile,
+    unihan_mock_zip_path: pathlib.Path,
+) -> None:
+    """The path core.download() returns is real and directly extractable."""
+    dest = tmp_path / "downloads" / "Unihan.zip"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    def urlretrieve(
+        url: str,
+        filename: StrPath | None = None,
+        reporthook: Callable[[int, int, int], object] | None = None,
+        data: _DataType | None = None,
+    ) -> tuple[str, HTTPMessage]:
+        shutil.copy(str(unihan_mock_zip_path), str(dest))
+        return ("", HTTPMessage())
+
+    result = core.download(
+        url="https://example.invalid/Unihan.zip",
+        dest=dest,
+        urlretrieve_fn=urlretrieve,
+    )
+
+    assert isinstance(result, pathlib.Path)
+    assert result == dest
+    assert core.has_valid_zip(result)
+    extracted = core.extract_zip(result, tmp_path / "work")
+    assert "Unihan_Readings.txt" in extracted.namelist()

--- a/tests/test_xdist_safety.py
+++ b/tests/test_xdist_safety.py
@@ -1,0 +1,104 @@
+"""Tests for xdist-safe shared-cache locking in the pytest plugin."""
+
+from __future__ import annotations
+
+import contextlib
+import multiprocessing
+import pathlib
+import types
+import typing as t
+import zipfile
+
+import pytest
+from filelock import FileLock
+
+from unihan_etl.pytest_plugin import _cache_lock, _sync_quick_dataset
+
+
+class CacheLockCase(t.NamedTuple):
+    """Case for :func:`test_cache_lock_selection`."""
+
+    test_id: str
+    under_xdist: bool
+    expect_filelock: bool
+
+
+CACHE_LOCK_CASES: list[CacheLockCase] = [
+    CacheLockCase(
+        test_id="off_xdist_nullcontext", under_xdist=False, expect_filelock=False
+    ),
+    CacheLockCase(
+        test_id="under_xdist_filelock", under_xdist=True, expect_filelock=True
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    CacheLockCase._fields,
+    CACHE_LOCK_CASES,
+    ids=[c.test_id for c in CACHE_LOCK_CASES],
+)
+def test_cache_lock_selection(
+    test_id: str,
+    under_xdist: bool,
+    expect_filelock: bool,
+    tmp_path: pathlib.Path,
+) -> None:
+    """_cache_lock is a no-op off xdist and a FileLock under an xdist worker.
+
+    Off xdist it must return a plain nullcontext (the downstream-safe path that
+    never touches filelock); only an actual worker, signalled by ``workerinput``
+    on the config, gets an inter-process lock.
+    """
+    config_ns = types.SimpleNamespace()
+    if under_xdist:
+        config_ns.workerinput = {}
+    config = t.cast("pytest.Config", config_ns)
+
+    lock = _cache_lock(config, tmp_path)
+
+    if expect_filelock:
+        assert isinstance(lock, FileLock)
+    else:
+        assert isinstance(lock, contextlib.nullcontext)
+    with lock:  # usable as a context manager either way
+        pass
+
+
+def _build_quick_cache(payload: tuple[t.Any, ...]) -> bool:
+    """Worker: build the quick cache while holding the shared inter-process lock.
+
+    Mirrors the locked region the quick fixtures run
+    (``with unihan_cache_lock: _sync_quick_dataset(...)``).
+    """
+    zip_path, sources, work_dir, out_dir, lock_path = payload
+    with FileLock(str(lock_path)):
+        return _sync_quick_dataset(zip_path, sources, work_dir, out_dir)
+
+
+def test_concurrent_cache_build_serializes(tmp_path: pathlib.Path) -> None:
+    """Two processes building the shared cache under the lock do not race.
+
+    Exercises the same locked region the quick fixtures use, across real OS
+    processes: the inter-process ``FileLock`` serializes them, so the archive is
+    built exactly once and stays valid. Cheaper and more deterministic than a
+    nested ``pytest-xdist`` run, and it never touches the real ``.unihan_cache``.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    readings = src / "Unihan_Readings.txt"
+    readings.write_text("U+3400\tkCantonese\tjau1\n", encoding="utf-8")
+    cache = tmp_path / "cache"
+    payload = (
+        cache / "downloads" / "Unihan.zip",
+        [readings],
+        cache / "work",
+        cache / "out",
+        tmp_path / "unihan_cache.lock",
+    )
+
+    with multiprocessing.Pool(2) as pool:
+        results = pool.map(_build_quick_cache, [payload, payload])
+
+    assert sum(bool(r) for r in results) == 1  # built once, not twice
+    assert zipfile.is_zipfile(payload[0])

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,24 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+]
+
+[[package]]
 name = "gp-furo-theme"
 version = "0.0.1a31"
 source = { registry = "https://pypi.org/simple" }
@@ -964,6 +982,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/d2/80606077b7fa8784417687f494ff801d7ab817d9a17fc94305811d5919bb/pytest_watcher-0.6.3.tar.gz", hash = "sha256:842dc904264df0ad2d5264153a66bb452fccfa46598cd6e0a5ef1d19afed9b13", size = 601878, upload-time = "2026-01-10T23:28:18.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/3f/172d73600ad2771774cda108efb813fc724fc345e5240a81a1085f1ade5d/pytest_watcher-0.6.3-py3-none-any.whl", hash = "sha256:83e7748c933087e8276edb6078663e6afa9926434b4fd8b85cf6b32b1d5bec89", size = 12431, upload-time = "2026-01-10T23:28:17.64Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -1655,6 +1686,12 @@ dependencies = [
     { name = "zhon" },
 ]
 
+[package.optional-dependencies]
+xdist = [
+    { name = "filelock" },
+    { name = "pytest-xdist" },
+]
+
 [package.dev-dependencies]
 coverage = [
     { name = "codecov" },
@@ -1664,6 +1701,7 @@ coverage = [
 dev = [
     { name = "codecov" },
     { name = "coverage" },
+    { name = "filelock" },
     { name = "gp-libs" },
     { name = "gp-sphinx" },
     { name = "mypy" },
@@ -1672,6 +1710,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1694,11 +1733,13 @@ docs = [
     { name = "sphinx-autodoc-pytest-fixtures" },
 ]
 testing = [
+    { name = "filelock" },
     { name = "gp-libs" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
 ]
 types = [
     { name = "types-appdirs" },
@@ -1711,10 +1752,13 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "appdirs" },
+    { name = "filelock", marker = "extra == 'xdist'" },
+    { name = "pytest-xdist", marker = "extra == 'xdist'" },
     { name = "pyyaml" },
     { name = "unicodecsv" },
     { name = "zhon", specifier = "~=2.0" },
 ]
+provides-extras = ["xdist"]
 
 [package.metadata.requires-dev]
 coverage = [
@@ -1725,6 +1769,7 @@ coverage = [
 dev = [
     { name = "codecov" },
     { name = "coverage" },
+    { name = "filelock" },
     { name = "gp-libs", specifier = ">=0.0.18" },
     { name = "gp-sphinx", specifier = "==0.0.1a31" },
     { name = "mypy" },
@@ -1733,6 +1778,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sphinx-autobuild" },
     { name = "sphinx-autodoc-api-style", specifier = "==0.0.1a31" },
@@ -1753,11 +1799,13 @@ docs = [
     { name = "sphinx-autodoc-pytest-fixtures", specifier = "==0.0.1a31" },
 ]
 testing = [
+    { name = "filelock" },
     { name = "gp-libs", specifier = ">=0.0.18" },
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
+    { name = "pytest-xdist" },
 ]
 types = [
     { name = "types-appdirs" },


### PR DESCRIPTION
## Summary

- **Fix** `Packager.download()` reusing a *corrupt* cached UNIHAN zip (which crashed extraction with `BadZipFile`) and ignoring a non-default `zip_path` filename — the download gate now reuses the cache only when it is a valid zip whose members pass a CRC check, and re-downloads to self-heal otherwise (covering a corrupt member payload, not just a truncated archive). This affected the published 0.42.0.
- **Fix** the bundled quick-dataset pytest fixtures serving stale data: editing, adding, or removing a `data_files/quick/*.txt` source now rebuilds the cached zip (CRC32) and regenerates the extracted/exported layers, instead of silently requiring a manual `.unihan_cache` wipe.
- **Fix** `unihan_quick_zip` / `unihan_mock_zip` yielding an already-closed `ZipFile`.
- **Add** xdist safety: writes to the shared `.unihan_cache` are serialized across workers via an inter-process lock (a no-op off xdist), with `pytest-xdist` + `filelock` as optional test dependencies (also a consumer-installable `unihan-etl[xdist]` extra) and a `just test-dist` parallel runner.
- **Fix** the `--no-cache` CLI help, which falsely claimed it caches "CSV outputs" (it only governs the zip download and extraction).
- **Add** caching/xdist test coverage: download gate, zip staleness (add/edit/remove/corrupt), derived-layer invalidation, extract gate, integrity-check memoization, lock selection, and a multiprocessing cross-process lock-contention test.

## Changes by area

### `src/unihan_etl/core.py`

- **`download()`**: gate the fetch on `has_valid_zip(dest)` (plus `cache`), replacing two dead/buggy nested predicates (a `Path.match` that was always `True`, and a hardcoded `"Unihan.zip"` existence check). Missing, corrupt, or custom-named `dest` is (re)fetched; a valid one is reused. Reached only via `Packager.download`.
- **`has_valid_zip()`**: validity verifies member CRCs (so a corrupt payload is caught, not just a bad header) and is memoized on the file's `(path, mtime, size)` fingerprint, so an unchanged cache is decompressed once rather than on every repeat check.
- **`--no-cache` help**: reworded to describe the zip re-download/re-extract it actually controls.

### `src/unihan_etl/pytest_plugin.py`

- **Staleness**: `_quick_zip_is_stale` / `_sync_quick_zip` / `_sync_quick_dataset` rebuild the cached quick zip when the member set or any member's CRC32 differs from the bundled sources, write it atomically (temp + `Path.replace`), and clear the derived `work/`/`out/` on a rebuild so extraction and export regenerate.
- **Open handles**: `unihan_quick_zip` and `unihan_mock_zip` yield an open archive (closed on teardown); NumPy `Teardown` docstring sections keep the docs builder warning-free.
- **xdist lock**: `unihan_cache_lock` is a `nullcontext` off xdist and a lazily-imported `filelock.FileLock` on `getbasetemp().parent` under an xdist worker (gated on `request.config.workerinput`; no `filelock` import or xdist fixture off that path, so the auto-loaded plugin stays importable for downstream consumers). It wraps the quick-zip rebuild and the quick/full download+export.

### `src/unihan_etl/cli/export.py`

- **`--no-cache` help**: same correction as core.py.

### Tooling & deps

- **`pyproject.toml`**: `pytest-xdist` + `filelock` added to the `dev`/`testing` groups and a consumer-installable `[project.optional-dependencies] xdist` extra (test-only; not a runtime dep, so default installs stay lean).
- **`justfile`**: a `test-dist` target (`uv run py.test -n auto`).

### Tests

- **`tests/test_unihan.py`**: `test_download_caching` (parametrized) + `test_download_returns_usable_path`.
- **`tests/test_caching.py`** (new): zip staleness, derived-layer invalidation, extract gate, mock-zip-open, and integrity-check memoization — hermetic (`tmp_path`, injected `urlretrieve_fn`, no network), typed `NamedTuple` + `test_id`.
- **`tests/test_xdist_safety.py`** (new): the lock-selection branch + a `multiprocessing` contention test — two processes build the shared cache under the lock and assert it is built exactly once and stays valid (the same locked region the fixtures run, across real processes; no nested `pytest-xdist` subprocess, so it is fast and deterministic).

### `CHANGES`

- `### Fixes` (download gate), `### Documentation` (`--no-cache` help), `### Development` (fixture staleness, open handles, xdist safety), under the unreleased section.

## Design decisions

- **Validity, not existence, gates the download cache.** This aligns `download()` with `Packager.download`'s `has_valid_zip` guard, so a corrupt cache self-heals instead of crashing extraction. Behavior is identical on the happy path.
- **Verify integrity once, then memoize.** `has_valid_zip` checks member CRCs so a corrupt payload (not just a truncated header) is caught, but caches the verdict per `(path, mtime, size)`, so the suite — and each xdist worker — decompresses an unchanged cache once, not on every check.
- **CRC32 for staleness, bidirectional.** The CRC is already stored per zip member (no sidecar, no dependency); a differing member set (add/remove) or a per-file CRC mismatch (edit) invalidates. `mtime` is rejected because `git checkout`/clone does not preserve it.
- **The xdist lock is opt-in and import-safe.** Off xdist it is a zero-cost `nullcontext`; `filelock` is imported lazily only on the worker path, so the pytest11 plugin never imports it for downstream (non-xdist) consumers, and no xdist-only fixture is requested. A clear error names `pytest-xdist` if `filelock` is absent on that path.
- **`--no-cache` help is corrected, not `export()`'s behavior.** `export()` genuinely doesn't cache output, and downstream (`format="python"`) neither rely on nor want output caching; changing `export()` to skip-when-exists would risk serving stale exports for no benefit.
- **Downstream-safe by construction and by test.** cihai and unihan-db suites pass against this branch via an editable overlay, covering the `Moo.zip`/`Packager.download` path and cihai's quick-fixture consumer.

## Deferred (out of scope)

- **`export()` actually caching/skipping output.** A real CSV↔nested round-trip is lossy and needs invalidation logic, with no downstream need; the help text now states reality instead.

## Verification

The dead/buggy download predicates are gone (expect no matches):

```
rg -n 'no_unihan_files_exist|data_dir\.match' src/unihan_etl/core.py
```

The download gate keys on zip validity (expect a match):

```
rg -n 'has_valid_zip\(dest\)' src/unihan_etl/core.py
```

The `--no-cache` help no longer claims CSV-output caching (expect no matches):

```
rg -n 'CSV outputs' src/unihan_etl
```

## Test plan

- [x] `uv run ruff check .` / `uv run ruff format .` — clean
- [x] `uv run mypy .` — clean (strict, whole tree)
- [x] `uv run py.test --reruns 0` — green (serial)
- [x] `just test-dist` (`-n auto`) — green in parallel
- [x] `just build-docs` — builds
- [x] download gate — cached-valid skips; absent/corrupt/custom-name/cache-off re-fetch
- [x] zip staleness — edit/add/remove/corrupt rebuild; unchanged skips; derived layers cleared on rebuild
- [x] integrity check memoized — the deep member-CRC check runs once per file state, re-runs after a rewrite
- [x] xdist — lock-selection branch (`nullcontext` vs `FileLock`); two processes building the shared cache under the lock serialize (built exactly once, archive valid)
- [x] cihai + unihan-db suites green against this branch (`uv run --with-editable ../unihan-etl`)
