### PR TITLE
docs: Fix reader-visible errors and complete cross-references

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,16 @@ _Notes on the upcoming release will go here._
 
 _Add your latest changes from PRs here_
 
+### Documentation
+
+- {ref}`quickstart` no longer shows a nonexistent `load` subcommand
+  and states the correct Python 3.10 minimum.
+- The {ref}`About UNIHAN <unihan>` image renders again, and the
+  {ref}`faq` shows as a heading instead of raw definition-list markup.
+- CLI, API, and topic pages now link the UNIHAN dataset, the
+  {class}`~unihan_etl.core.Packager` API, and external tools on first
+  mention.
+
 ## unihan-etl 0.43.0 (2026-06-28)
 
 unihan-etl 0.43.0 hardens cache handling and the bundled pytest fixtures. The downloader now reuses a cached UNIHAN archive only when it is a valid zip — re-fetching a corrupt or truncated cache instead of crashing extraction — and honors a custom `zip_path` filename. The quick-dataset pytest fixtures rebuild themselves when their source data changes and are now safe to run under `pytest-xdist`, and the `unihan-etl export` `--no-cache` help now describes what it actually controls.

--- a/MIGRATION
+++ b/MIGRATION
@@ -38,7 +38,7 @@ Before 0.39.1, running the bare command would download and export UNIHAN data:
 $ unihan-etl
 ```
 
-From 0.40.0+, use the `export` subcommand explicitly:
+From 0.40.0+, use the `export` {ref}`subcommand <cli-export>` explicitly:
 
 ```console
 $ unihan-etl export
@@ -112,7 +112,7 @@ The Python API remains unchanged. If you use unihan-etl as a library, no changes
 
 ## unihan-etl 0.22.0 (2023-06-17)
 
-### Move `unihan_etl.process` to `unihan_etl.core` (#284)
+### Move `unihan_etl.process` to {mod}`unihan_etl.core` (#284)
 
 Before 0.22.0:
 
@@ -126,9 +126,9 @@ From 0.22.0+:
 >>> from unihan_etl.core import Packager
 ```
 
-### Options is now a dataclass object (#280)
+### {class}`~unihan_etl.options.Options` is now a dataclass object (#280)
 
-A typed, autocomplete-friendly :obj:`dataclasses.dataclass` object is now used for the unihan_etl options object.
+A typed, autocomplete-friendly {obj}`dataclasses.dataclass` object is now used for the unihan-etl options object.
 
 Before 0.22.0:
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -22,7 +22,7 @@ If you need an API stabilized please [file an issue](https://github.com/cihai/un
 :::{grid-item-card} Core
 :link: core
 :link-type: doc
-ETL pipeline and Packager: download, normalize, export.
+ETL pipeline and {class}`~unihan_etl.core.Packager`: download, normalize, export.
 :::
 
 :::{grid-item-card} Options
@@ -34,13 +34,13 @@ Configuration dataclass for paths, formats, and field selection.
 :::{grid-item-card} Expansion
 :link: expansion
 :link-type: doc
-Expand multi-value UNIHAN fields into structured data.
+Expand multi-value {ref}`UNIHAN <unihan>` fields into structured data.
 :::
 
 :::{grid-item-card} Types
 :link: types
 :link-type: doc
-Shared TypedDicts and type aliases.
+Shared {class}`~typing.TypedDict` structures and type aliases.
 :::
 
 :::{grid-item-card} Constants
@@ -71,7 +71,7 @@ Legacy test harness.
 :::{grid-item-card} pytest plugin
 :link: pytest-plugin
 :link-type: doc
-Fixtures for quick and full UNIHAN datasets in pytest.
+Fixtures for quick and full UNIHAN datasets in [pytest](https://docs.pytest.org/).
 :::
 
 ::::

--- a/docs/api/pytest-plugin.md
+++ b/docs/api/pytest-plugin.md
@@ -2,7 +2,7 @@
 
 # `pytest` plugin
 
-unihan-etl ships a pytest plugin that downloads `UNIHAN.zip` once and reuses
+unihan-etl ships a [pytest](https://docs.pytest.org/) plugin that downloads `Unihan.zip` once and reuses
 it across tests, plus an isolated home directory for cache and config setup.
 The plugin auto-discovers via the `pytest11` entry point — installing
 `unihan-etl` is enough to make every fixture below available in your tests.
@@ -26,10 +26,10 @@ def test_with_raw_snippet(unihan_quick_data: str) -> None:
 
 ## Which Fixture Do I Need?
 
-- Use {fixture}`unihan_quick_packager` when you want a small, fast UNIHAN dataset for unit tests.
-- Use {fixture}`unihan_full_packager` when you need the complete UNIHAN corpus.
+- Use {fixture}`unihan_quick_packager` when you want a small, fast {ref}`UNIHAN <unihan>` dataset for unit tests.
+- Use {fixture}`unihan_full_packager` when you need the complete UNIHAN corpus — it downloads the full database and is slower than the quick dataset.
 - Use {fixture}`unihan_bootstrap_all` (autouse-wrapped) when you want both datasets pre-downloaded at session start.
-- Use {fixture}`unihan_quick_data` when you only need a raw text snippet rather than a fully bootstrapped Packager.
+- Use {fixture}`unihan_quick_data` when you only need a raw text snippet rather than a fully bootstrapped {class}`~unihan_etl.core.Packager`.
 - Override {fixture}`unihan_cache_path` (or {fixture}`unihan_project_cache_path`) to redirect where cached UNIHAN data lives.
 - Override {fixture}`unihan_home_user_name` when you need a custom test user identity.
 

--- a/docs/cli/download.md
+++ b/docs/cli/download.md
@@ -2,7 +2,7 @@
 
 # unihan-etl download
 
-Download and cache the UNIHAN database without exporting.
+Download and cache the {ref}`UNIHAN <unihan>` database without exporting.
 
 ## Command
 

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -2,7 +2,7 @@
 
 # unihan-etl export
 
-Export UNIHAN data to CSV, JSON, or YAML format.
+Export {ref}`UNIHAN <unihan>` data to CSV, JSON, or YAML format.
 
 ## Command
 

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -16,6 +16,12 @@ Export {ref}`UNIHAN <unihan>` data to CSV, JSON, or YAML format.
 
 ## Examples
 
+Export with the defaults — CSV, with the download cached:
+
+```console
+$ unihan-etl export
+```
+
 Export all UNIHAN data to JSON:
 
 ```console

--- a/docs/cli/fields.md
+++ b/docs/cli/fields.md
@@ -2,7 +2,7 @@
 
 # unihan-etl fields
 
-List available UNIHAN fields with their descriptions and source files.
+List available {ref}`UNIHAN <unihan>` fields with their descriptions and source files.
 
 ## Command
 

--- a/docs/cli/files.md
+++ b/docs/cli/files.md
@@ -2,7 +2,7 @@
 
 # unihan-etl files
 
-List available UNIHAN source files.
+List available {ref}`UNIHAN <unihan>` source files.
 
 ## Command
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -60,7 +60,7 @@ files
 
 ## Main command
 
-The `unihan-etl` command is the entry point for all UNIHAN ETL operations. Use subcommands to export data, download the database, or query fields and files.
+The `unihan-etl` command is the entry point for all {ref}`UNIHAN <unihan>` ETL operations. Use subcommands to export data, download the database, or query fields and files.
 
 ### Command
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -75,15 +75,6 @@ The `unihan-etl` command is the entry point for all {ref}`UNIHAN <unihan>` ETL o
         See :ref:`cli-export`
 ```
 
-## Global Options
-
-- `-l, --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}`: Logging level (default: INFO)
-- `-V, --version`: Show version and exit
-
 ## Output Formats
 
-The `fields`, `files`, and `search` commands support different output formats:
-
-- **Table** (default): Human-readable formatted output
-- `--json`: Pretty-printed JSON (entire result as array/object)
-- `--ndjson`: Newline-delimited JSON (one record per line, ideal for LLM consumption)
+The `fields`, `files`, and `search` commands print a human-readable table by default, and can emit JSON for programmatic use — see each command's page for the exact flags.

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -2,7 +2,7 @@
 
 # unihan-etl search
 
-Look up character data in the UNIHAN database.
+Look up character data in the {ref}`UNIHAN <unihan>` database.
 
 ## Command
 

--- a/docs/cli/search.md
+++ b/docs/cli/search.md
@@ -34,7 +34,7 @@ Look up by hex codepoint:
 $ unihan-etl search 4E00
 ```
 
-Get JSON output for LLM consumption:
+Get the result as JSON:
 
 ```console
 $ unihan-etl search 一 --json

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,9 @@
 
 # unihan-etl
 
-Download, search, and export Unicode's UNIHAN CJK character dataset. Normalizes raw Unicode data files into clean JSON, CSV, or YAML.
+Download, search, and export Unicode's {ref}`UNIHAN <unihan>` CJK character dataset. Normalizes raw Unicode data files into clean JSON, CSV, or YAML.
 
-unihan-etl handles the data pipeline. For SQLAlchemy models, see [unihan-db](https://unihan-db.git-pull.com/). For end-user character lookups, see [cihai](https://cihai.git-pull.com/).
+unihan-etl handles the data pipeline. For [SQLAlchemy](https://www.sqlalchemy.org/) models, see [unihan-db](https://unihan-db.git-pull.com/). For end-user character lookups, see [cihai](https://cihai.git-pull.com/).
 
 ::::{grid} 1 2 3 3
 :gutter: 2 2 3 3
@@ -58,19 +58,19 @@ $ pip install unihan-etl
 
 ## At a glance
 
-Fetches raw UNIHAN data from unicode.org.
+{ref}`Fetch <cli-download>` raw UNIHAN data from [unicode.org](https://www.unicode.org/).
 
 ```console
 $ unihan-etl download
 ```
 
-Look up a character across all fields.
+{ref}`Look up <cli-search>` a character across all fields.
 
 ```console
 $ unihan-etl search 好
 ```
 
-Export the full dataset to JSON (also supports CSV, YAML).
+{ref}`Export <cli-export>` the full dataset to JSON (also supports CSV, YAML).
 
 ```console
 $ unihan-etl export -F json

--- a/docs/internals/api/index.md
+++ b/docs/internals/api/index.md
@@ -1,13 +1,9 @@
-(internal_api)=
+(internals-api)=
 
 # Internal API
 
-```{module} unihan_etl
-
-```
-
 :::{warning}
-Be careful with these! Internal APIs are **not** covered by version policies. They can break or be removed between minor versions!
+Be careful with these! Internal APIs are **not** covered by version policies. They can break or be removed in any release!
 
 If you need an internal API stabilized please [file an issue](https://github.com/cihai/unihan-etl/issues).
 :::

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -7,8 +7,8 @@ Everything in this section is **internal implementation detail**. There is
 no stability guarantee. Interfaces may change or be removed without notice
 between any release.
 
-If you are building an application with unihan-etl, use the [CLI](../cli/index.md)
-or the [public API](../api/index.md).
+If you are building an application with unihan-etl, use the {ref}`CLI <cli>`
+or the {ref}`public API <api>`.
 ```
 
 ::::{grid} 1 1 2 2

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,9 +1,5 @@
 (migration)=
 
-```{currentmodule} libtmux
-
-```
-
 ```{include} ../MIGRATION
 
 ```

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -10,23 +10,33 @@ guide:
 
 ## Quick start
 
+Clone the repository:
+
 ```console
 $ git clone https://github.com/cihai/unihan-etl.git
 ```
+
+Enter the project directory:
 
 ```console
 $ cd unihan-etl
 ```
 
+Install the development dependencies:
+
 ```console
 $ uv sync --group dev
 ```
+
+Run the test suite:
 
 ```console
 $ uv run py.test
 ```
 
 ## Continuous testing
+
+Re-run the tests on every change with [pytest-watcher](https://github.com/olzhasar/pytest-watcher):
 
 ```console
 $ uv run ptw .

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -16,7 +16,7 @@ Development setup, running tests, submitting PRs.
 :::{grid-item-card} Code Style
 :link: code-style
 :link-type: doc
-Ruff, mypy, NumPy docstrings, import conventions.
+[Ruff](https://docs.astral.sh/ruff/), [mypy](https://mypy.readthedocs.io/), NumPy docstrings, import conventions.
 :::
 
 :::{grid-item-card} Releasing

--- a/docs/project/releasing.md
+++ b/docs/project/releasing.md
@@ -11,7 +11,7 @@ releases may include breaking API changes.
 
 1. Update `CHANGES` with new entries under the next version heading.
 2. Bump the version in `pyproject.toml`.
-3. Commit: `git commit -m "chore: release vX.Y.Z"`.
+3. Commit: `git commit -m "Tag vX.Y.Z"`.
 4. Tag: `git tag vX.Y.Z`.
 5. Push: `git push --follow-tags`.
 6. CI publishes to PyPI automatically on tagged pushes.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,10 @@
 
 # Quickstart
 
+unihan-etl downloads the Unicode {ref}`UNIHAN <unihan>` database and
+exports it to CSV, JSON, or YAML. A plain `unihan-etl export` works out
+of the box — the download is cached for reuse.
+
 ## Installation
 
 Ensure you have at least Python **>= 3.10**.
@@ -12,7 +16,7 @@ Using [uv]:
 $ uv add unihan-etl
 ```
 
-Run the CLI once without a persistent install via `uvx`:
+Run the CLI once without a persistent install via [uvx]:
 
 ```console
 $ uvx unihan-etl
@@ -34,8 +38,8 @@ $ pip install --user --upgrade unihan-etl
 
 ### Developmental releases
 
-New versions of unihan-etl are published to PyPI as alpha, beta, or release candidates.
-In their versions you will see notification like `a1`, `b1`, and `rc1`, respectively.
+unihan-etl publishes alpha, beta, and release-candidate versions to [PyPI](https://pypi.org/project/unihan-etl/).
+Their version numbers carry `a1`, `b1`, and `rc1` suffixes, respectively.
 For example, `0.27.0a1` is the first alpha release of `0.27.0` before general availability.
 
 - [uv]:
@@ -102,12 +106,12 @@ via trunk (can break easily):
 
 ## Commands
 
+Run `unihan-etl` without arguments to list its subcommands; the {ref}`CLI reference <cli>` documents each one.
+
 ```console
 $ unihan-etl
 ```
 
 ## Pythonics
 
-:::{seealso}
-
-{ref}`unihan-etl API documentation <api>`.
+For the rarer cases, you can drive the same pipeline from Python — see the {ref}`API reference <api>` for {class}`~unihan_etl.core.Packager` and {class}`~unihan_etl.options.Options`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@
 
 ## Installation
 
-Assure you have at least python **>= 3.7**.
+Ensure you have at least Python **>= 3.10**.
 
 Using [uv]:
 
@@ -56,7 +56,7 @@ For example, `0.27.0a1` is the first alpha release of `0.27.0` before general av
   $ pipx install --suffix=@next 'unihan-etl' --pip-args '\--pre' --force
   ```
 
-  Then run `unihan-etl@next load [session]`.
+  Then run `unihan-etl@next export`.
 
 - [uv tool install][uv-tools]:
 
@@ -70,7 +70,7 @@ For example, `0.27.0a1` is the first alpha release of `0.27.0` before general av
   $ uvx --from 'unihan-etl' --prerelease allow unihan-etl
   ```
 
-  Then rerun with your desired arguments, e.g. `uvx --prerelease allow unihan-etl load [session]`.
+  Then rerun with your desired arguments, e.g. `uvx --prerelease allow unihan-etl export`.
 
 via trunk (can break easily):
 

--- a/docs/topics/faq.md
+++ b/docs/topics/faq.md
@@ -2,10 +2,10 @@
 
 # Frequently Asked Questions
 
-... Why are some fields, e.g. _kTotalStrokes_, in lists when there's seemingly not any multi-value data?
+## Why are some fields, e.g. [kTotalStrokes](https://www.unicode.org/reports/tr38/#kTotalStrokes), in lists when there's seemingly no multi-value data?
 
-: The word back from the developers of UNIHAN is they keep some fields
-multi-valued for future use.
+The word back from the developers of {ref}`UNIHAN <unihan>` is they keep
+some fields multi-valued for future use.
 
 > Apparently at the moment there is only one record with two values for
 > the kTotalStrokes field in the Unihan database. However, the maintainers
@@ -13,6 +13,6 @@ multi-valued for future use.
 > future, and as documented in UAX #38.
 >
 > May 30, 2017 (Unicode 9.0)
->
-> unihan-etl is designed to handle fields correctly and consistently
-> according to the documentation in the database.
+
+unihan-etl handles these fields consistently, following the documentation
+in the database.

--- a/docs/topics/unihan.md
+++ b/docs/topics/unihan.md
@@ -32,10 +32,10 @@ extend and promote use of the Unicode Standard.
 ## What is UNIHAN?
 
 UNIHAN, short for [Han unification][han unification], is the effort of the consortium
-assign codepoints to CJK characters. Any single {}`han character` can
+assign codepoints to CJK characters. Any single [han character] can
 multiple historical or regional variants to account for, hence "unification".
 
-```{image} _static/img/sword_variants.png
+```{image} ../_static/img/sword_variants.png
 :width: 300px
 :align: center
 

--- a/docs/topics/unihan.md
+++ b/docs/topics/unihan.md
@@ -163,12 +163,12 @@ U+5364  kHanyuPinyin    10093.130:xī,lǔ 74609.020:lǔ,xī
 U+5EFE  kHanyuPinyin    10513.110,10514.010,10514.020:gǒng
 ```
 
-Data could be exported to a CSV, but users wouldn't be able to
-handle delimited values and structured information held within.
+You could export the data to CSV, but you couldn't work with the
+delimited values and structured information held within.
 
 Since CSV cannot hold structured information, you need a format that can.
 
-Even then, users may not want an export that expands the structured
-output of fields. So if a tool exists, exports should be configurable. Users
-could then export a field with `gun3 hung1 zung1` pristinely without
-turning it into list form.
+Even then, you may not want an export that expands fields into
+structured output. A tool has to make expansion configurable, so you
+can export a field like `gun3 hung1 zung1` as-is instead of turning it
+into a list.

--- a/docs/topics/unihan.md
+++ b/docs/topics/unihan.md
@@ -26,13 +26,13 @@ character.
 
 This entails pulling together minds from around the world to assign codepoints.
 
-The _Unicode Consortium_ is a non-profit organization founded to develop,
+The [Unicode Consortium](https://en.wikipedia.org/wiki/Unicode_Consortium) is a non-profit organization founded to develop,
 extend and promote use of the Unicode Standard.
 
 ## What is UNIHAN?
 
-UNIHAN, short for [Han unification][han unification], is the effort of the consortium
-assign codepoints to CJK characters. Any single [han character] can
+UNIHAN, short for [Han unification][han unification], is the effort of the consortium to
+assign codepoints to CJK characters. Any single [han character] can have
 multiple historical or regional variants to account for, hence "unification".
 
 ```{image} ../_static/img/sword_variants.png
@@ -43,15 +43,15 @@ multiple historical or regional variants to account for, hence "unification".
 
 To do this, various sources of information are pulled together and cross-referenced
 to detail characteristics of the glyphs, and vet them through a thorough
-proofreading process. It's an international effort, hallmarked by between
+proofreading process. It's an international effort, hallmarked by collaboration between
 researchers and groups like the [Ideographic Rapporteur Group][ideographic rapporteur group]. Glyphs
 once only noted in dictionaries and antiquity are set in stone with
 their own codepoints, carefully cross-referenced with information from,
 often multiple, distinct sources.
 
-The advantage that UNIHAN provides to east asian researchers, including
+The advantage that UNIHAN provides to East Asian researchers, including
 sinologists and japanologists, linguists, analysts, language learners, and
-hobbyists cannot be understated. Unbeknownst to users, its used under the hood
+hobbyists cannot be overstated. Unbeknownst to users, it's used under the hood
 in many applications and websites.
 
 The resulting standard has industrial ramifications downstream to
@@ -83,7 +83,7 @@ on each field of information is derived from. For instance:
   9. 朗文初級中文詞典, Hong Kong: Longman, 2001.
 
 - [kHanYu](http://www.unicode.org/reports/tr38/#kHanYu): The position of this
-  character in the Hanyu Da Zidian (HDZ) Chinese character dictionary.
+  character in the [Hanyu Da Zidian][hànyǔ dà zìdiǎn] (HDZ) Chinese character dictionary.
 
   Bibliography:
 
@@ -111,28 +111,28 @@ Han Unification is a global effort. And it's available free to the world.
 
 ## The problem
 
-It's difficult to readily take advantage of UNIHAN database in its
+It's difficult to readily take advantage of the UNIHAN database in its
 raw form.
 
 UNIHAN comprises over 20 MB of character information, separated
-across multiple files. Within these files is _90_ fields, spanning 8
-general categories of data. Within some of fields, there are specific
-considerations to take account of to use the data correctly, for instance:
+across multiple files. Within these files are _90_ fields, spanning 8
+general categories of data. Some fields need specific handling to use
+the data correctly, for instance:
 
 UNIHAN's values place references to its own codepoints, such as
-_kDefinition_:
+[kDefinition](http://www.unicode.org/reports/tr38/#kDefinition):
 
 ```
 U+3400       kDefinition     (same as U+4E18 丘) hillock or mound
 ```
 
-And also by spaces, such as in _kCantonese_:
+Values are also separated by spaces, as in _kCantonese_:
 
 ```
 U+342B       kCantonese      gun3 hung1 zung1
 ```
 
-And by spaces which specify different sources, like _kMandarin_, "When
+Other fields use spaces to distinguish sources, like [kMandarin](http://www.unicode.org/reports/tr38/#kMandarin), "When
 there are two values, then the first is preferred for zh-Hans (CN) and the
 second is preferred for zh-Hant (TW). When there is only one value, it is
 appropriate for both.":
@@ -141,7 +141,7 @@ appropriate for both.":
 U+7E43        kMandarin       běng bēng
 ```
 
-Another, values are delimited in various ways, for instance, by rules,
+Values are also delimited by per-field rules,
 like _kDefinition_, "Major definitions are separated by semicolons, and minor
 definitions by commas.":
 
@@ -166,8 +166,7 @@ U+5EFE  kHanyuPinyin    10513.110,10514.010,10514.020:gǒng
 Data could be exported to a CSV, but users wouldn't be able to
 handle delimited values and structured information held within.
 
-Since CSV does not support structured information, another format that
-supports needs to be found.
+Since CSV cannot hold structured information, you need a format that can.
 
 Even then, users may not want an export that expands the structured
 output of fields. So if a tool exists, exports should be configurable. Users


### PR DESCRIPTION
## Summary

- **Fix** reader-visible errors that shipped in 0.43.0: the quickstart pointed at a nonexistent `unihan-etl load [session]` subcommand and a stale Python 3.7 floor, the About UNIHAN illustration failed to load, and the FAQ rendered as raw Pandoc definition-list markup because that MyST extension isn't enabled.
- **Fix** two Sphinx build warnings — an unreadable image path (the page had moved into `docs/topics/` without updating its relative path) and a duplicate `unihan_etl` module declaration.
- **Add** first-mention cross-references throughout: the UNIHAN dataset, the `Packager`/`Options` API, and external projects (SQLAlchemy, pytest, Ruff, mypy, uvx, PyPI, unicode.org) are now linked from the prose that names them.
- **Replace** RST role syntax and a stray `libtmux` module directive in the migration guide, and internal Markdown links with `{ref}` roles.
- **Remove** prose flag inventories from the CLI reference (the argparse blocks already own them) and tighten voice on the quickstart, export, and UNIHAN pages.

This branch brings the documentation into line with the site's voice and cross-reference guide. It is docs-only: no library or CLI behavior changes.

## Changes

### Corrected commands and facts

- **`docs/quickstart.md`**: `load [session]` → `export`; Python floor corrected to 3.10; opens with a lead paragraph instead of jumping into installation.
- **`docs/migration.md` / `MIGRATION`**: drop the stray `{currentmodule} libtmux` directive; RST `:obj:` → MyST `{obj}`; link `Options`, `unihan_etl.core`, and the `export` subcommand.
- **`docs/project/releasing.md`**: release commit example matches the project's `Tag v<version>` convention.

### Restored rendering

- **`docs/topics/unihan.md`**: image path repaired; empty `{}` role replaced with the `[han character]` link.
- **`docs/topics/faq.md`**: the disabled definition-list becomes a `##` heading with prose, and a sentence prettier had folded into the Unicode maintainers' quotation is lifted back out.
- **`docs/internals/api/index.md`**: removes the duplicate `{module}` declaration; renames the `internal_api` anchor to the hyphenated `internals-api`.

### Completed cross-references

- **CLI, API, topic, and landing pages**: first prose mention of UNIHAN links the About UNIHAN page; `Packager`, `Options`, and `TypedDict` link the API; external tools link their sites.
- **`docs/internals/index.md`**: relative Markdown links to the CLI and API pages become `{ref}` roles.

### Voice and shape

- **`docs/cli/index.md`**: drops the `## Global Options` prose list (argparse renders `-l`/`-V`) and reframes `## Output Formats` by concept.
- **`docs/cli/export.md`**: examples lead with the bare default invocation.
- **`docs/topics/unihan.md`**: grammar and typos repaired; the closing paragraphs address the reader in second person.
- **`docs/api/pytest-plugin.md`**: `UNIHAN.zip` → `Unihan.zip`; the full-corpus fixture now states its download cost.

## Design decisions

- **Type-check step runs `mypy`, not `ty`**: the repo's configured checker is mypy (`[tool.mypy]` + dev dep); `ty` isn't wired into `pyproject.toml`, so the docs gate uses `uv run mypy .`. A best-effort `uvx ty check` reports pre-existing diagnostics on untouched source, unrelated to these changes.
- **Left the pytest-plugin `## Configuration` / `autofixtures` sections in place**: they document the gp-sphinx toolchain (a separate repo), so revising them is out of scope for this branch.

## Test plan

- [x] `uv run ruff check .` — lint clean
- [x] `uv run ruff format --check .` — formatting clean
- [x] `uv run mypy .` — type check clean (configured checker)
- [x] `uv run py.test` — doctests under `docs/`, `README.md`, and the included `MIGRATION` pass
- [x] `just build-docs` — no new Sphinx warnings; the previously-broken image and duplicate-module warnings are resolved
- [x] Rendered spot-check of the restructured `faq.md`, `cli/index.md`, and the restored image in `topics/unihan.md`