### PR TITLE
docs(attrs): Document dataclass, NamedTuple, and TypedDict fields

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,13 @@ Workflow actions moved to their current major releases: `actions/checkout` v7,
 and `dorny/paths-filter` v4. Workflow behavior is unchanged, though setup-uv no
 longer prunes the uv cache, so the first run after this repopulates it.
 
+#### Class fields describe themselves in the API reference (#362)
+
+The dataclass, `NamedTuple`, and `TypedDict` fields across the options,
+expansion, and export surface now say what each one holds. They previously
+reached the rendered API reference as "Alias for field number 0" or as a
+bare name carrying only its type.
+
 ## unihan-etl 0.43.0 (2026-06-28)
 
 unihan-etl 0.43.0 hardens cache handling and the bundled pytest fixtures. The downloader now reuses a cached UNIHAN archive only when it is a valid zip — re-fetching a corrupt or truncated cache instead of crashing extraction — and honors a custom `zip_path` filename. The quick-dataset pytest fixtures rebuild themselves when their source data changes and are now safe to run under `pytest-xdist`, and the `unihan-etl export` `--no-cache` help now describes what it actually controls.

--- a/src/unihan_etl/_internal/app_dirs.py
+++ b/src/unihan_etl/_internal/app_dirs.py
@@ -37,6 +37,30 @@ MISSING_DIR = pathlib.Path(str(hash(dataclasses.MISSING)))
 class AppDirs:
     """Wrap :class:`appdirs.AppDirs`'s paths in typed :class:`pathlib.Path`'s.
 
+    Every directory defaults to ``MISSING_DIR``, the sentinel marking a path as
+    unsupplied: those are filled in from the wrapped :class:`appdirs.AppDirs`,
+    while supplied paths keep their value after environment variable, XDG, and
+    tilde expansion.
+
+    Attributes
+    ----------
+    user_data_dir : pathlib.Path
+        Per-user data directory; unihan-etl writes its exports here by default.
+    site_data_dir : pathlib.Path
+        Data directory shared by every user on the machine.
+    user_config_dir : pathlib.Path
+        Per-user configuration directory.
+    site_config_dir : pathlib.Path
+        Configuration directory shared by every user on the machine.
+    user_cache_dir : pathlib.Path
+        Per-user cache directory; the downloaded UNIHAN zip and the files
+        extracted from it live under it by default.
+    user_state_dir : pathlib.Path
+        Per-user directory for state that outlives a run without being
+        configuration.
+    user_log_dir : pathlib.Path
+        Per-user log directory.
+
     Retrieve directories as dataclass in :class:`pathlib.Path` format:
 
     >>> from appdirs import AppDirs as BaseAppDirs

--- a/src/unihan_etl/_internal/app_dirs.py
+++ b/src/unihan_etl/_internal/app_dirs.py
@@ -61,6 +61,8 @@ class AppDirs:
     user_log_dir : pathlib.Path
         Per-user log directory.
 
+    Examples
+    --------
     Retrieve directories as dataclass in :class:`pathlib.Path` format:
 
     >>> from appdirs import AppDirs as BaseAppDirs

--- a/src/unihan_etl/expansion.py
+++ b/src/unihan_etl/expansion.py
@@ -165,7 +165,23 @@ def expand_kUnihanCore2020(
 
 
 class kLocationDict(t.TypedDict):
-    """kLocation mapping."""
+    """kLocation mapping.
+
+    Position in the Hanyu Da Zidian, parsed from an ``ABCDE.XYZ`` reference.
+
+    Attributes
+    ----------
+    volume : int
+        Volume number, ``1`` through ``8``.
+    page : int
+        Page number within the volume.
+    character : int
+        Position of the character on the page.
+    virtual : int
+        ``0`` for a character printed in the dictionary, greater than ``0`` for
+        one assigned a virtual position, counting up for each character given
+        the same virtual position.
+    """
 
     volume: int
     page: int
@@ -235,7 +251,21 @@ def expand_kIRGHanyuDaZidian(value: list[str]) -> list[kLocationDict]:
 
 
 class kTGHZ2013LocationDict(t.TypedDict):
-    """kTGHZ2013 location mapping."""
+    """kTGHZ2013 location mapping.
+
+    Position in the Tōngyòng Guīfàn Hànzì Zìdiǎn, parsed from a
+    ``page.positionentry`` reference.
+
+    Attributes
+    ----------
+    page : int
+        Page number, zero-padded to three digits in the source.
+    position : int
+        Position of the entry on the page.
+    entry_type : int
+        ``0`` for a main entry, greater than ``0`` for a parenthesized or
+        bracketed variant of the main entry.
+    """
 
     page: int
     position: int
@@ -245,7 +275,15 @@ class kTGHZ2013LocationDict(t.TypedDict):
 
 
 class kTGHZ2013Dict(t.TypedDict):
-    """kTGHZ2013 mapping."""
+    """kTGHZ2013 mapping.
+
+    Attributes
+    ----------
+    reading : str
+        Pīnyīn reading, taken from after the colon.
+    locations : Sequence[kTGHZ2013LocationDict]
+        Dictionary positions the reading is given at.
+    """
 
     reading: str
     locations: Sequence[kTGHZ2013LocationDict]
@@ -309,7 +347,18 @@ def expand_kTGHZ2013(
 
 
 class kSMSZD2003IndexDict(t.TypedDict):
-    """kSMSZD2003Index location mapping."""
+    """kSMSZD2003Index location mapping.
+
+    Position in the Soengmou San Zidin (商務新字典), parsed from a
+    ``page.position`` reference.
+
+    Attributes
+    ----------
+    page : int
+        Page number.
+    position : int
+        Position of the entry on the page.
+    """
 
     page: int
     position: int
@@ -405,14 +454,33 @@ def expand_kSMSZD2003Readings(
 
 
 class kHanyuPinyinPreDict(t.TypedDict):
-    """kHanyuPinyin predicate mapping."""
+    """kHanyuPinyin predicate mapping.
+
+    Staging shape held while a kHanyuPinyin value is being split apart.
+
+    Attributes
+    ----------
+    locations : Sequence[str | kLocationDict]
+        Hanyu Da Zidian references from before the colon, each a raw string
+        until it is replaced by its parsed :class:`kLocationDict`.
+    readings : list[str]
+        Pīnyīn readings from after the colon.
+    """
 
     locations: Sequence[str | kLocationDict]
     readings: list[str]
 
 
 class kHanyuPinyinDict(t.TypedDict):
-    """kHanyuPinyin mapping."""
+    """kHanyuPinyin mapping.
+
+    Attributes
+    ----------
+    locations : kLocationDict
+        Hanyu Da Zidian position(s) the readings are given at.
+    readings : list[str]
+        Pīnyīn readings from after the colon.
+    """
 
     locations: kLocationDict
     readings: list[str]
@@ -459,7 +527,24 @@ def expand_kHanyuPinyin(
 
 
 class kXHC1983LocationDict(t.TypedDict):
-    """kXHC1983 location mapping."""
+    """kXHC1983 location mapping.
+
+    Position in the 1983 Xiàndài Hànyǔ Cídiǎn, parsed from a
+    ``page.positionentry`` reference with an optional trailing ``*``.
+
+    Attributes
+    ----------
+    page : int
+        Page number, zero-padded to four digits in the source.
+    character : int
+        Position of the entry on the page.
+    entry : int | None
+        ``0`` for a main entry, greater than ``0`` for a parenthesized variant
+        of the main entry.
+    substituted : bool
+        Whether the reference carried a trailing ``*``, marking an encoded
+        variant standing in for a character the dictionary prints unencoded.
+    """
 
     page: int
     character: int
@@ -468,14 +553,33 @@ class kXHC1983LocationDict(t.TypedDict):
 
 
 class kXHC1983Dict(t.TypedDict):
-    """kXHC1983 mapping."""
+    """kXHC1983 mapping.
+
+    Attributes
+    ----------
+    locations : kXHC1983LocationDict
+        Dictionary position(s) the reading is given at.
+    reading : str
+        Pīnyīn reading, taken from after the colon.
+    """
 
     locations: kXHC1983LocationDict
     reading: str
 
 
 class kXHC1983PreDict(t.TypedDict):
-    """kXHC1983 predicate mapping."""
+    """kXHC1983 predicate mapping.
+
+    Staging shape held while a kXHC1983 value is being split apart.
+
+    Attributes
+    ----------
+    locations : list[str] | kXHC1983LocationDict
+        Location references from before the colon, each a raw string until it
+        is replaced by its parsed :class:`kXHC1983LocationDict`.
+    reading : str
+        Pīnyīn reading from after the colon.
+    """
 
     locations: list[str] | kXHC1983LocationDict
     reading: str
@@ -604,7 +708,20 @@ def expand_kRSAdobe_Japan1_6(value: list[str]) -> list[kRSAdobe_Japan1_6Dict]:
 
 
 class kCihaiTDict(t.TypedDict):
-    """kCihaiT mapping."""
+    """kCihaiT mapping.
+
+    Position in the Cihai (辭海), parsed from a decimal reference whose digits
+    encode page, row, and position.
+
+    Attributes
+    ----------
+    page : int
+        Page number, the digits left of the decimal point.
+    row : int
+        Row on the page, the first digit after the decimal point.
+    character : int
+        Position within the row, the remaining two digits.
+    """
 
     page: int
     row: int
@@ -661,7 +778,21 @@ def expand_kIICore(
 
 
 class kDaeJaweonDict(t.TypedDict):
-    """kDaehwan mapping."""
+    """kDaehwan mapping.
+
+    Position in the Dae Jaweon, parsed from a ``page.position`` reference whose
+    final digit flags virtual entries.
+
+    Attributes
+    ----------
+    page : int
+        Page number.
+    character : int
+        Position of the character on the page.
+    virtual : int
+        ``0`` for a character printed in the dictionary, ``1`` for one absent
+        from it and assigned a virtual position.
+    """
 
     page: int
     character: int
@@ -774,7 +905,23 @@ def expand_kHanyuPinlu(value: list[str]) -> list[kHanyuPinluDict]:
 
 
 class LocationDict(t.TypedDict):
-    """Location mapping."""
+    """Location mapping.
+
+    Hanyu Da Zidian position in the same ``ABCDE.XYZ`` form the kHanYu field
+    uses.
+
+    Attributes
+    ----------
+    volume : int
+        Volume number, ``1`` through ``8``.
+    page : int
+        Page number within the volume.
+    character : int
+        Position of the character on the page.
+    virtual : int
+        ``0`` for a character printed in the dictionary, ``1`` for one assigned
+        a virtual position.
+    """
 
     volume: int
     page: int
@@ -783,7 +930,17 @@ class LocationDict(t.TypedDict):
 
 
 class kHDZRadBreakDict(t.TypedDict):
-    """kHDZRadBreak mapping."""
+    """kHDZRadBreak mapping.
+
+    Attributes
+    ----------
+    radical : str
+        Radical the Hanyu Da Zidian break begins with.
+    ucn : str
+        Code point of that radical, in ``U+2Fxx`` Kangxi Radicals form.
+    location : LocationDict
+        Hanyu Da Zidian position where the break begins.
+    """
 
     radical: str
     ucn: str
@@ -832,7 +989,17 @@ def expand_kHDZRadBreak(value: str) -> kHDZRadBreakDict:
 
 
 class kSBGYDict(t.TypedDict):
-    """kSBGY mapping."""
+    """kSBGY mapping.
+
+    Position in the Song Ben Guang Yun, parsed from an ``ABC.XY`` reference.
+
+    Attributes
+    ----------
+    page : int
+        Page number.
+    character : int
+        Position of the character on the page.
+    """
 
     page: int
     character: int
@@ -982,7 +1149,20 @@ expand_kIRG_VSource = _expand_kIRG_GenericSource
 
 
 class kGSRDict(t.TypedDict):
-    """kGSR mapping."""
+    """kGSR mapping.
+
+    Position in Bernhard Karlgren's Grammata Serica Recensa.
+
+    Attributes
+    ----------
+    set : int
+        Set number, from the four leading digits.
+    letter : str
+        Entry letter within the set, ``a`` through ``v`` or ``x`` through
+        ``z``.
+    apostrophe : bool
+        Whether the entry letter is followed by an apostrophe.
+    """
 
     set: int
     letter: str
@@ -1020,7 +1200,18 @@ def expand_kGSR(value: list[str]) -> list[kGSRDict]:
 
 
 class kCheungBauerIndexDict(t.TypedDict):
-    """kCheungBauer mapping."""
+    """kCheungBauer mapping.
+
+    Page-and-position reference, shared by the kCheungBauerIndex and kFennIndex
+    fields.
+
+    Attributes
+    ----------
+    page : int
+        Page number, the digits before the period.
+    character : int
+        Position of the character on the page.
+    """
 
     page: int
     character: int

--- a/src/unihan_etl/expansion.py
+++ b/src/unihan_etl/expansion.py
@@ -74,7 +74,17 @@ kAlternateTotalStrokesLiteral = t.Literal[
 
 
 class kAlternateTotalStrokesDict(t.TypedDict):
-    """kAlternateTotalStrokes mapping."""
+    """kAlternateTotalStrokes mapping.
+
+    Attributes
+    ----------
+    sources : list[kAlternateTotalStrokesLiteral]
+        IRG source letters the stroke count applies to, one per letter of the
+        run after the colon. ``["-"]`` stands for the bare ``-`` value, which
+        names no individual source.
+    strokes : int | None
+        Alternate total stroke count, ``None`` when the value states no count.
+    """
 
     sources: list[kAlternateTotalStrokesLiteral]
     strokes: int | None
@@ -412,7 +422,18 @@ def expand_kSMSZD2003Index(
 
 
 class kSMSZD2003ReadingsDict(t.TypedDict):
-    """kSMSZD2003Readings location mapping."""
+    """kSMSZD2003Readings location mapping.
+
+    Readings the Soengmou San Zidin (商務新字典) gives for a character, split on
+    the ``粵`` marker that separates the two romanizations.
+
+    Attributes
+    ----------
+    mandarin : list[str]
+        Comma-separated pīnyīn readings, from before the marker.
+    cantonese : list[str]
+        Comma-separated jyutping readings, from after the marker.
+    """
 
     mandarin: list[str]
     cantonese: list[str]
@@ -627,7 +648,22 @@ def expand_kXHC1983(
 
 
 class kCheungBauerDict(t.TypedDict):
-    """kCheungBauer mapping."""
+    """kCheungBauer mapping.
+
+    Attributes
+    ----------
+    radical : int
+        Kangxi radical number, from the three-digit half of the radical-stroke
+        index.
+    strokes : int
+        Residual stroke count, from the two-digit half of the radical-stroke
+        index.
+    cangjie : str | None
+        Cangjie input code, ``None`` when the entry supplies none.
+    readings : list[str]
+        Cantonese jyutping readings, in the alphabetical order they are listed
+        in.
+    """
 
     radical: int
     strokes: int
@@ -759,7 +795,16 @@ def expand_kCihaiT(value: list[str]) -> list[kCihaiTDict]:
 
 
 class kIICoreDict(t.TypedDict):
-    """kIICore mapping."""
+    """kIICore mapping.
+
+    Attributes
+    ----------
+    priority : str
+        Priority letter, ``A``, ``B``, or ``C``.
+    sources : list[str]
+        Source letters that carry the character: the IRG source letters, with
+        ``P`` used in place of ``KP``.
+    """
 
     priority: str
     sources: list[str]
@@ -843,7 +888,17 @@ def expand_kIRGDaeJaweon(value: list[str]) -> list[kDaeJaweonDict]:
 
 
 class kFennDict(t.TypedDict):
-    """kFenn mapping."""
+    """kFenn mapping.
+
+    Attributes
+    ----------
+    phonetic : str
+        Phonetic group number, kept as a string because an entry may carry a
+        trailing ``a``.
+    frequency : str
+        Frequency-of-use grade printed after the phonetic group: ``A`` through
+        ``K``, ``P``, or ``*``.
+    """
 
     phonetic: str
     frequency: str
@@ -874,7 +929,16 @@ def expand_kFenn(value: list[str]) -> list[kFennDict]:
 
 
 class kHanyuPinluDict(t.TypedDict):
-    """kHanyuPinlu mapping."""
+    """kHanyuPinlu mapping.
+
+    Attributes
+    ----------
+    phonetic : str
+        Pīnyīn reading.
+    frequency : int
+        Parenthesized number following the reading: the sum of the frequencies
+        recorded for it in HYPLCD.
+    """
 
     phonetic: str
     frequency: int
@@ -1034,7 +1098,19 @@ class kRSSimplifiedType(enum.Enum):
 
 
 class kRSGenericDict(t.TypedDict):
-    """kRSGeneric mapping."""
+    """kRSGeneric mapping.
+
+    Attributes
+    ----------
+    radical : int
+        Kangxi radical number, ``1`` through ``214``.
+    strokes : int
+        Residual stroke count: the strokes left once those belonging to the
+        radical are removed.
+    simplified : kRSSimplifiedType | t.Literal[False]
+        Which simplified version of the radical the apostrophe suffix marks,
+        ``False`` when the radical carries no apostrophe.
+    """
 
     radical: int
     strokes: int
@@ -1115,7 +1191,18 @@ expand_kRSUnicode = _expand_kRSGeneric
 
 
 class SourceLocationDict(t.TypedDict):
-    """Source location mapping."""
+    """Source location mapping.
+
+    IRG source reference, split on the hyphen.
+
+    Attributes
+    ----------
+    source : str
+        Source identifier before the hyphen, such as ``JMJ`` or ``SAT``.
+    location : str | None
+        Identifier within that source, after the hyphen. ``None`` when the
+        value carries no hyphen.
+    """
 
     source: str
     location: str | None
@@ -1276,7 +1363,17 @@ kStrangeLiteral = t.Literal[
 
 
 class kStrangeDict(t.TypedDict):
-    """kStrange mapping."""
+    """kStrange mapping.
+
+    Attributes
+    ----------
+    property_type : kStrangeLiteral
+        Category letter for what makes the ideograph strange, such as ``B``
+        for bopomofo-like or ``M`` for mirrored.
+    characters : Sequence[str]
+        Code points listed after the category letter, empty when the category
+        stands on its own.
+    """
 
     property_type: kStrangeLiteral
     characters: Sequence[str]
@@ -1331,7 +1428,18 @@ def expand_kStrange(
 
 
 class kMojiJohoVariationDict(t.TypedDict):
-    """Variation sequence of Moji Jōhō Kiban entry."""
+    """Variation sequence of Moji Jōhō Kiban entry.
+
+    Attributes
+    ----------
+    serial_number : str
+        Database serial number of the variant, such as ``MJ000023``.
+    variation_sequence : str
+        Variation selector paired with that serial number, such as ``E0101``.
+    standard : bool
+        Whether the variant repeats the entry's own serial number, which marks
+        its registered IVS as the default (encoded) form.
+    """
 
     serial_number: str
     variation_sequence: str
@@ -1342,7 +1450,17 @@ class kMojiJohoVariationDict(t.TypedDict):
 
 
 class kMojiJohoDict(t.TypedDict):
-    """kMojiJoho mapping."""
+    """kMojiJoho mapping.
+
+    Attributes
+    ----------
+    serial_number : str
+        Database serial number of the character, the first space-separated
+        value.
+    variants : list[kMojiJohoVariationDict]
+        Serial number and variation sequence pairs that follow it, empty when
+        the value carries the serial number alone.
+    """
 
     serial_number: str
     variants: list[kMojiJohoVariationDict]
@@ -1397,7 +1515,18 @@ def expand_kMojiJoho(
 
 
 class kFanqieDict(t.TypedDict):
-    """kFanqie mapping."""
+    """kFanqie mapping.
+
+    The two characters of a fǎnqiè spelling, which together give a Middle
+    Chinese pronunciation.
+
+    Attributes
+    ----------
+    initial : str
+        First character, supplying the initial.
+    final : str
+        Second character, supplying the final.
+    """
 
     initial: str
     final: str
@@ -1428,7 +1557,16 @@ def expand_kFanqie(value: list[str]) -> list[kFanqieDict]:
 
 
 class kZhuangDict(t.TypedDict):
-    """kZhuang mapping."""
+    """kZhuang mapping.
+
+    Attributes
+    ----------
+    reading : str
+        Zhuang reading, with any trailing ``*`` stripped off.
+    non_standard : bool
+        Whether the source value ended in ``*``, marking the reading as
+        non-standard.
+    """
 
     reading: str
     non_standard: bool

--- a/src/unihan_etl/options.py
+++ b/src/unihan_etl/options.py
@@ -24,7 +24,39 @@ if t.TYPE_CHECKING:
 
 @dataclasses.dataclass()
 class Options:
-    """Options for unihan-etl."""
+    """Options for unihan-etl.
+
+    Attributes
+    ----------
+    source : str | pathlib.Path
+        URL or local path of the UNIHAN zip to read.
+    destination : pathlib.Path
+        Export path. An ``{ext}`` placeholder in it is filled with ``format``.
+    zip_path : pathlib.Path
+        Path the zip is downloaded to and read back from.
+    work_dir : pathlib.Path
+        Directory the zip's data files are extracted into.
+    fields : Sequence[str]
+        UNIHAN fields to export, index fields included.
+    format : t.Literal["json", "csv", "yaml", "python"]
+        Export format.
+    input_files : list[str]
+        Files inside the zip to pull records from.
+    download : bool
+        Flag for fetching the zip up front. Downloading happens on demand in
+        :meth:`unihan_etl.core.Packager.download`, which does not consult it.
+    expand : bool
+        Expand multi-value fields into structured values. CSV exports stay
+        flat either way.
+    prune_empty : bool
+        Drop fields with empty values from exported records. Applies only
+        alongside ``expand``.
+    cache : bool
+        Reuse a valid zip and already extracted files rather than downloading
+        and extracting again.
+    log_level : LogLevel
+        Level the logger is set up at.
+    """
 
     source: str | pathlib.Path = UNIHAN_URL
     destination: pathlib.Path = DESTINATION_DIR / "unihan.{ext}"

--- a/src/unihan_etl/types.py
+++ b/src/unihan_etl/types.py
@@ -50,7 +50,39 @@ UnihanFormats = t.Literal["json", "csv", "yaml", "python"]
 
 @dataclasses.dataclass()
 class Options:
-    """unihan-etl options."""
+    """unihan-etl options.
+
+    Attributes
+    ----------
+    source : str
+        URL or path of the UNIHAN zip to read.
+    destination : pathlib.Path
+        Export path, with any ``{ext}`` placeholder already resolved.
+    zip_path : pathlib.Path
+        Path the zip is downloaded to and read back from.
+    work_dir : pathlib.Path
+        Directory the zip's data files are extracted into.
+    fields : tuple[str, ...]
+        UNIHAN fields to export, index fields included.
+    format : UnihanFormats
+        Export format.
+    input_files : list[str]
+        Files inside the zip to pull records from.
+    download : bool
+        Flag for fetching the zip up front. Downloading happens on demand in
+        :meth:`unihan_etl.core.Packager.download`, which does not consult it.
+    expand : bool
+        Expand multi-value fields into structured values. CSV exports stay
+        flat either way.
+    prune_empty : bool
+        Drop fields with empty values from exported records. Applies only
+        alongside ``expand``.
+    cache : bool
+        Reuse a valid zip and already extracted files rather than downloading
+        and extracting again.
+    log_level : LogLevel
+        Level the logger is set up at.
+    """
 
     source: str
     destination: pathlib.Path


### PR DESCRIPTION
Adds NumPy-style `Attributes` sections to the dataclasses, `NamedTuple`s, and `TypedDict`s in `_internal.app_dirs`, `expansion`, `options`, and `types`. Without them the API reference renders each field either bare or as `Alias for field number 0`, so a reader had no way to tell what a page, volume, or sentinel value actually means, or which options the CSV exporter ignores. The change is docstrings only — no code, signature, or field-order changes.

Gates run and passing: `just ruff-format`, `just ruff`, `uv run mypy .`, `just test`, `just build-docs`.

Docs build succeeds and this branch contributes no duplicate-object warnings. The `AppDirs` docstring closes its `Attributes` section with an `Examples` header, so the trailing usage prose and doctests are no longer consumed as attribute entries. The remaining `duplicate object description of ..., other instance in api/expansion` warnings are the field-vs-autodoc overlap — the NumPy preprocessor emits an `.. attribute::` entry for a field autodoc also renders — which is fixed upstream in gp-sphinx and pending release, not something to suppress in `docs/conf.py` here; with that fix in place the build reports none. The pre-existing `invalid signature for autoattribute` warnings on hyphenated keys (`zh-Hans`, `zh-Hant`, `strokes-residue`) and the `undefined label: 'set_home'` warning are unchanged from master.

Closes #362
